### PR TITLE
This PR adds `Enter` and `q` as alternative keys to close the "Hop Detail" dialog in the TUI.

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -155,8 +155,11 @@ where
             }
 
             if ui_state.show_hop_detail {
-                if key.code == KeyCode::Esc {
-                    ui_state.show_hop_detail = false;
+                match key.code {
+                    KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+                        ui_state.show_hop_detail = false;
+                    }
+                    _ => {}
                 }
                 continue;
             }

--- a/src/tui/views/hop.rs
+++ b/src/tui/views/hop.rs
@@ -548,7 +548,7 @@ impl Widget for HopDetailView<'_> {
 
         lines.push(Line::from(""));
         lines.push(Line::from(vec![Span::styled(
-            "  [Esc] back",
+            "  [Esc/Enter/q] back",
             Style::default().fg(self.theme.text_dim),
         )]));
 


### PR DESCRIPTION
### Summary
This PR adds `Enter` and `q` as alternative keys to close the "Hop Detail" dialog in the TUI.
### Motivation
Previously, `Esc` was the only way to exit this view. This change improves accessibility for users who may have a non-functional Escape key and adds `Enter` as a convenient toggle (since `Enter` opens the view).
### Changes
- Modified [src/tui/app.rs](cci:7://file:///home/themoog/ttl/src/tui/app.rs:0:0-0:0) to handle `KeyCode::Enter` and `KeyCode::Char('q')` in the hop detail input loop.
- Updated the UI hint in [src/tui/views/hop.rs](cci:7://file:///home/themoog/ttl/src/tui/views/hop.rs:0:0-0:0) to display `[Esc/Enter/q] back`.
### Verification
- [x] Verified that pressing `Enter` closes the dialog.
- [x] Verified that pressing `q` closes the dialog.
- [x] Verified that `Esc` still works as expected.