### PR TITLE
Fix FreeBSD build: make getifs conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,21 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+  build-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.2"
+          usesh: true
+          prepare: |
+            pkg install -y curl
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          run: |
+            . $HOME/.cargo/env
+            cargo build --verbose
+            cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **FreeBSD build failure**: Fix `cargo install ttl` on FreeBSD by making `getifs` dependency conditional. Gateway detection unavailable on FreeBSD (uses macOS-specific APIs).
+
+### Changed
+- **CI**: Added FreeBSD 14.2 build testing via vmactions/freebsd-vm
+
 ## [0.14.2] - 2026-01-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ clap_complete = "4.5"
 socket2 = { version = "0.6", features = ["all"] }
 pnet = "0.35"
 libc = "0.2"
-getifs = "0.4"  # Fast gateway detection via kernel APIs (netlink/sysctl)
 
 # DNS (note: trust-dns-resolver is now hickory-resolver)
 hickory-resolver = "0.25"
@@ -63,6 +62,11 @@ update-informer = { version = "1", default-features = false, features = ["github
 
 # TTY detection
 is-terminal = "0.4"
+
+# Gateway detection - Linux (netlink) and macOS (sysctl) only
+# FreeBSD excluded: getifs uses macOS-specific APIs (NET_RT_IFLIST2, rt_msghdr)
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+getifs = "0.4"
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
## Summary
- Fix `cargo install ttl` failing on FreeBSD due to `getifs` crate using macOS-specific APIs
- Make `getifs` a target-specific dependency (Linux + macOS only)
- Gateway detection returns `None` on FreeBSD (non-critical feature - just won't show gateway IP in TUI title bar)
- Add FreeBSD 14.2 CI job via vmactions/freebsd-vm

## Test plan
- [x] Linux build passes
- [x] Tests pass
- [ ] FreeBSD CI job passes
- [ ] @nullstream confirms `cargo install ttl` works on FreeBSD 13/14

Fixes #14