### PR TITLE
Add trace diffing (--diff) and streaming JSON output (--stream-json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Trace diffing** (`--diff before.json after.json`): compare two saved sessions hop by hop. Reports path changes (primary responder differs), added/lost hops, ECMP responder-set changes, avg RTT deltas (highlighted when ≥5ms and ≥20%), loss changes, and destination reachability. `--json` emits the diff as machine-readable JSON.
+- **Streaming JSON output** (`--stream-json`): emit each probe event (reply/timeout/late_reply) as one line of JSON on stdout for piping to jq/grep/monitoring pipelines. Event lines match the saved-session `events` schema with a `target` field added; a per-target `summary` line is emitted at end of stream. Implies `--no-tui`; memory stays bounded on infinite runs.
+
+### Dependencies
+- maxminddb 0.27.3 → 0.28.1, getifs 0.4.0 → 0.6.1, tokio 1.52.1 → 1.52.3, serde_json 1.0.149 → 1.0.150, clap_complete 4.6.3 → 4.6.5
+
 ## [0.19.1] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ See [Installation](#installation) below for setup instructions.
 - **ICMP, UDP, TCP probing** with auto-detection
 - **Great TUI** with themes, sparklines, and session export
 - **Update notifications** - in-app banner when new versions are available
-- **Scriptable** - JSON, CSV, and text report output
+- **Scriptable** - JSON, CSV, text report, and line-delimited JSON streaming output
+- **Trace diffing** - compare two saved sessions for path and latency changes
 
 See [docs/FEATURES.md](docs/FEATURES.md) for detailed documentation, including optional setup for [GeoIP](docs/FEATURES.md#geoip-location) and [IX detection](docs/FEATURES.md#ix-detection).
 
@@ -190,6 +191,8 @@ ttl 8.8.8.8 1.1.1.1      # Multiple targets (Tab to switch)
 ttl 1.1.1.1 -c 100 --report    # Text report
 ttl 1.1.1.1 -c 100 --json      # JSON export
 ttl 1.1.1.1 -c 100 --csv       # CSV export
+ttl 1.1.1.1 --stream-json      # Stream events as line-delimited JSON
+ttl --diff before.json after.json    # Compare two saved sessions
 ttl --replay results.json      # Replay saved session
 ttl --replay results.json --animate  # Animated replay
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,11 +115,11 @@
 
 **Why this matters:** Users frequently need to compare traces taken at different times (before/after a change, during/after an incident). Streaming output enables integration with monitoring pipelines.
 
-- [ ] Trace comparison (`ttl --diff trace1.json trace2.json`)
-- [ ] Show added/removed/changed hops between two sessions
-- [ ] Highlight latency and path changes
-- [ ] Streaming JSON output (`--stream-json`) for piping to other tools
-- [ ] Line-delimited JSON (one event per line, composable with jq/grep)
+- [x] Trace comparison (`ttl --diff trace1.json trace2.json`)
+- [x] Show added/removed/changed hops between two sessions
+- [x] Highlight latency and path changes
+- [x] Streaming JSON output (`--stream-json`) for piping to other tools
+- [x] Line-delimited JSON (one event per line, composable with jq/grep)
 
 ### Docker & Daemon Mode
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -492,6 +492,63 @@ ttl 8.8.8.8 -c 100 --report
 
 Human-readable summary similar to mtr report mode.
 
+### Streaming JSON
+
+```bash
+ttl 8.8.8.8 --stream-json                    # One JSON event per line
+ttl 8.8.8.8 --stream-json -c 10 | jq .       # Finite run, piped to jq
+ttl 8.8.8.8 --stream-json | jq 'select(.type == "timeout")'
+```
+
+Emits each probe event as a single line of JSON on stdout (NDJSON), suitable
+for piping into `jq`, `grep`, or monitoring pipelines. Implies `--no-tui` and
+runs until `-c` rounds complete or Ctrl-C.
+
+Event lines match the schema of the `events` array in saved session files,
+with a `target` field added for demultiplexing multi-target runs:
+
+```json
+{"target":"8.8.8.8","offset_ms":1052,"ttl":5,"seq":1,"flow_id":0,"type":"reply","addr":"192.178.105.139","rtt_us":12500}
+{"target":"8.8.8.8","offset_ms":4021,"ttl":7,"seq":1,"flow_id":0,"type":"timeout"}
+```
+
+Event types are `reply`, `timeout`, and `late_reply`. When the stream ends, a
+final `summary` line is emitted per target:
+
+```json
+{"target":"8.8.8.8","type":"summary","complete":true,"dest_ttl":13,"total_sent":130,"hops_responding":12}
+```
+
+### Trace Diff
+
+```bash
+ttl --diff before.json after.json            # Human-readable comparison
+ttl --diff before.json after.json --json     # Machine-readable diff
+```
+
+Compare two saved sessions hop by hop. Reports:
+
+- **`[path]`** — primary responder changed at a hop
+- **`[added]`** / **`[lost]`** — hop responds in only one session
+- **Responder-set changes** — ECMP responders that appeared or disappeared
+- **Latency shifts** — avg RTT deltas, highlighted when ≥5ms *and* ≥20% of the
+  before value
+- **Loss changes** and destination reachability
+
+```
+Trace diff: 8.8.8.8
+  before: before.json  (2026-06-09 14:00:12 UTC)
+  after:  after.json   (2026-06-10 09:30:44 UTC)
+
+ TTL  Before           After            Change       Avg RTT (ms)       Loss (%)
+   1  192.168.1.1      192.168.1.1                    2.0 →     2.1    0.0 →   0.0
+   2  10.0.2.1         10.0.2.99        [path]        8.0 →     9.0    0.0 →   0.0
+   3  10.0.3.1         *                [lost]       12.0 →       -    0.0 →     -
+
+Summary: 1 path change(s), 0 hop(s) added, 1 hop(s) lost, 0 significant latency shift(s)
+  destination reached in both (5 → 5 hops)
+```
+
 ### Session Replay
 
 ```bash
@@ -559,6 +616,8 @@ Options:
       --report           Batch report mode (requires -c)
       --json             JSON output (requires -c)
       --csv              CSV output (requires -c)
+      --stream-json      Stream probe events as line-delimited JSON (implies --no-tui)
+      --diff <BEFORE> <AFTER>  Compare two saved sessions (with --json for JSON output)
       --replay <FILE>    Replay a saved JSON session
       --animate          Animate replay (show probe-by-probe discovery)
       --speed <N>        Replay speed multiplier (default: 10.0, requires --animate)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,10 @@ EXAMPLES:
     Export results:
         ttl -c 100 --json host > out.json
 
+    Stream and compare:
+        ttl --stream-json host | jq .   # Line-delimited JSON events
+        ttl --diff before.json after.json
+
 DETECTION INDICATORS:
     [NAT]  - Source port rewriting detected (affects multi-flow accuracy)
     [RL?]  - Router rate-limiting ICMP (loss may be artificial)
@@ -41,7 +45,7 @@ For detailed documentation: https://github.com/lance0/ttl/blob/master/docs/FEATU
 ")]
 pub struct Args {
     /// Target hosts to trace (IP address or hostname)
-    #[arg(required_unless_present_any = ["completions", "replay"])]
+    #[arg(required_unless_present_any = ["completions", "replay", "diff"])]
     pub targets: Vec<String>,
 
     /// Number of probe rounds (0 = infinite). Each round sends probes to all TTLs.
@@ -139,6 +143,14 @@ pub struct Args {
     /// Replay speed multiplier (1.0 = realtime, 10.0 = 10x faster)
     #[arg(long = "speed", default_value = "10.0", requires = "animate")]
     pub speed: f32,
+
+    /// Compare two saved sessions: show added/removed hops, path and latency changes
+    #[arg(long = "diff", num_args = 2, value_names = ["BEFORE", "AFTER"], conflicts_with_all = ["targets", "replay"])]
+    pub diff: Option<Vec<String>>,
+
+    /// Stream probe events as line-delimited JSON to stdout (implies --no-tui)
+    #[arg(long = "stream-json", conflicts_with_all = ["json", "csv", "report", "replay", "diff"])]
+    pub stream_json: bool,
 
     /// Color theme (default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized)
     #[arg(long = "theme", default_value = "default")]
@@ -325,6 +337,8 @@ mod tests {
             replay: None,
             animate: false,
             speed: 10.0,
+            diff: None,
+            stream_json: false,
             theme: "default".to_string(),
             wide: false,
             interface: None,
@@ -392,5 +406,38 @@ mod tests {
         });
         let err = args.validate().unwrap_err();
         assert!(err.contains("sequence wrap"));
+    }
+
+    #[test]
+    fn test_diff_parses_two_files_without_targets() {
+        let args = Args::try_parse_from(["ttl", "--diff", "before.json", "after.json"]).unwrap();
+        assert_eq!(
+            args.diff,
+            Some(vec!["before.json".to_string(), "after.json".to_string()])
+        );
+        assert!(args.targets.is_empty());
+    }
+
+    #[test]
+    fn test_diff_requires_exactly_two_files() {
+        assert!(Args::try_parse_from(["ttl", "--diff", "only-one.json"]).is_err());
+    }
+
+    #[test]
+    fn test_diff_conflicts_with_targets() {
+        assert!(Args::try_parse_from(["ttl", "--diff", "a.json", "b.json", "8.8.8.8"]).is_err());
+    }
+
+    #[test]
+    fn test_stream_json_parses_with_target() {
+        let args = Args::try_parse_from(["ttl", "--stream-json", "8.8.8.8"]).unwrap();
+        assert!(args.stream_json);
+    }
+
+    #[test]
+    fn test_stream_json_conflicts_with_batch_output() {
+        assert!(Args::try_parse_from(["ttl", "--stream-json", "--json", "8.8.8.8"]).is_err());
+        assert!(Args::try_parse_from(["ttl", "--stream-json", "--csv", "8.8.8.8"]).is_err());
+        assert!(Args::try_parse_from(["ttl", "--stream-json", "--report", "8.8.8.8"]).is_err());
     }
 }

--- a/src/export/diff.rs
+++ b/src/export/diff.rs
@@ -1,0 +1,555 @@
+//! Session diff: compare two saved traces and report path/latency changes.
+
+use crate::lookup::sanitize_display;
+use crate::state::{Hop, Session};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::io::Write;
+use std::net::IpAddr;
+
+/// Minimum absolute avg RTT shift (ms) considered significant
+const RTT_ABS_THRESHOLD_MS: f64 = 5.0;
+/// Minimum relative avg RTT shift (fraction of the before value) considered significant
+const RTT_REL_THRESHOLD: f64 = 0.20;
+
+/// How a hop changed between the two sessions
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HopChange {
+    /// Responds in both sessions with the same primary responder
+    Unchanged,
+    /// Primary responder differs between sessions
+    PathChange,
+    /// Responds only in the after session
+    Added,
+    /// Responds only in the before session
+    Lost,
+}
+
+/// Snapshot of a responding hop in one session
+#[derive(Debug, Clone, Serialize)]
+pub struct HopSnapshot {
+    pub primary: Option<IpAddr>,
+    pub hostname: Option<String>,
+    pub avg_rtt_ms: Option<f64>,
+    pub loss_pct: f64,
+    /// All responder IPs seen at this hop (sorted)
+    pub responders: Vec<IpAddr>,
+}
+
+impl HopSnapshot {
+    /// Build a snapshot if the hop responded at least once
+    fn from_hop(hop: &Hop) -> Option<Self> {
+        if hop.received == 0 {
+            return None;
+        }
+        let primary_stats = hop.primary_stats();
+        let mut responders: Vec<IpAddr> = hop.responders.keys().copied().collect();
+        responders.sort();
+        Some(Self {
+            primary: hop.primary,
+            hostname: primary_stats.and_then(|s| s.hostname.clone()),
+            avg_rtt_ms: primary_stats.map(|s| s.avg_rtt().as_secs_f64() * 1000.0),
+            loss_pct: hop.loss_pct(),
+            responders,
+        })
+    }
+}
+
+/// Diff of a single TTL between two sessions
+#[derive(Debug, Clone, Serialize)]
+pub struct HopDiff {
+    pub ttl: u8,
+    pub change: HopChange,
+    pub before: Option<HopSnapshot>,
+    pub after: Option<HopSnapshot>,
+    /// after - before, when both sessions have RTT data
+    pub avg_rtt_delta_ms: Option<f64>,
+    /// after - before, when the hop responds in both sessions
+    pub loss_delta_pct: Option<f64>,
+    /// Whether the RTT shift exceeds both absolute (5ms) and relative (20%) thresholds
+    pub rtt_significant: bool,
+    pub responders_added: Vec<IpAddr>,
+    pub responders_removed: Vec<IpAddr>,
+}
+
+/// Complete diff between two sessions
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionDiff {
+    pub before_file: String,
+    pub after_file: String,
+    pub target_before: String,
+    pub target_after: String,
+    pub started_before: DateTime<Utc>,
+    pub started_after: DateTime<Utc>,
+    pub complete_before: bool,
+    pub complete_after: bool,
+    pub dest_ttl_before: Option<u8>,
+    pub dest_ttl_after: Option<u8>,
+    /// Per-TTL diffs, only for hops that responded in at least one session
+    pub hops: Vec<HopDiff>,
+}
+
+impl SessionDiff {
+    pub fn count(&self, change: HopChange) -> usize {
+        self.hops.iter().filter(|h| h.change == change).count()
+    }
+
+    pub fn rtt_shifts(&self) -> usize {
+        self.hops.iter().filter(|h| h.rtt_significant).count()
+    }
+
+    /// True if anything changed: path, hop presence, or significant latency
+    pub fn has_changes(&self) -> bool {
+        self.rtt_shifts() > 0
+            || self.hops.iter().any(|h| {
+                h.change != HopChange::Unchanged
+                    || !h.responders_added.is_empty()
+                    || !h.responders_removed.is_empty()
+            })
+    }
+}
+
+/// Compare two sessions hop by hop
+pub fn diff_sessions(
+    before: &Session,
+    after: &Session,
+    before_file: &str,
+    after_file: &str,
+) -> SessionDiff {
+    let max_len = before.hops.len().max(after.hops.len());
+    let mut hops = Vec::new();
+
+    for i in 0..max_len {
+        let snap_before = before.hops.get(i).and_then(HopSnapshot::from_hop);
+        let snap_after = after.hops.get(i).and_then(HopSnapshot::from_hop);
+        let ttl = (i + 1) as u8;
+
+        let change = match (&snap_before, &snap_after) {
+            (None, None) => continue, // silent in both: nothing to report
+            (None, Some(_)) => HopChange::Added,
+            (Some(_), None) => HopChange::Lost,
+            (Some(b), Some(a)) => {
+                if b.primary == a.primary {
+                    HopChange::Unchanged
+                } else {
+                    HopChange::PathChange
+                }
+            }
+        };
+
+        let avg_rtt_delta_ms = match (&snap_before, &snap_after) {
+            (Some(b), Some(a)) => match (b.avg_rtt_ms, a.avg_rtt_ms) {
+                (Some(rb), Some(ra)) => Some(ra - rb),
+                _ => None,
+            },
+            _ => None,
+        };
+        let loss_delta_pct = match (&snap_before, &snap_after) {
+            (Some(b), Some(a)) => Some(a.loss_pct - b.loss_pct),
+            _ => None,
+        };
+        let rtt_significant = match (avg_rtt_delta_ms, &snap_before) {
+            (Some(delta), Some(b)) => {
+                let base = b.avg_rtt_ms.unwrap_or(0.0);
+                delta.abs() >= RTT_ABS_THRESHOLD_MS && delta.abs() >= base * RTT_REL_THRESHOLD
+            }
+            _ => false,
+        };
+
+        let (responders_added, responders_removed) = match (&snap_before, &snap_after) {
+            (Some(b), Some(a)) => (
+                a.responders
+                    .iter()
+                    .filter(|ip| !b.responders.contains(ip))
+                    .copied()
+                    .collect(),
+                b.responders
+                    .iter()
+                    .filter(|ip| !a.responders.contains(ip))
+                    .copied()
+                    .collect(),
+            ),
+            _ => (Vec::new(), Vec::new()),
+        };
+
+        hops.push(HopDiff {
+            ttl,
+            change,
+            before: snap_before,
+            after: snap_after,
+            avg_rtt_delta_ms,
+            loss_delta_pct,
+            rtt_significant,
+            responders_added,
+            responders_removed,
+        });
+    }
+
+    SessionDiff {
+        before_file: before_file.to_string(),
+        after_file: after_file.to_string(),
+        target_before: before.target.display_name(),
+        target_after: after.target.display_name(),
+        started_before: before.started_at,
+        started_after: after.started_at,
+        complete_before: before.complete,
+        complete_after: after.complete,
+        dest_ttl_before: before.dest_ttl,
+        dest_ttl_after: after.dest_ttl,
+        hops,
+    }
+}
+
+/// ANSI color codes (only applied when `color` is true)
+struct Palette {
+    color: bool,
+}
+
+impl Palette {
+    fn paint(&self, code: &str, s: &str) -> String {
+        if self.color {
+            format!("\x1b[{}m{}\x1b[0m", code, s)
+        } else {
+            s.to_string()
+        }
+    }
+    fn green(&self, s: &str) -> String {
+        self.paint("32", s)
+    }
+    fn red(&self, s: &str) -> String {
+        self.paint("31", s)
+    }
+    fn yellow(&self, s: &str) -> String {
+        self.paint("33", s)
+    }
+    fn dim(&self, s: &str) -> String {
+        self.paint("2", s)
+    }
+}
+
+/// Format a hop's display name: hostname if known, else primary IP, else "*"
+fn host_label(snap: &Option<HopSnapshot>) -> String {
+    match snap {
+        Some(s) => match (&s.hostname, s.primary) {
+            (Some(h), _) => sanitize_display(h),
+            (None, Some(ip)) => ip.to_string(),
+            (None, None) => "*".to_string(),
+        },
+        None => "*".to_string(),
+    }
+}
+
+fn fmt_rtt(v: Option<f64>) -> String {
+    match v {
+        Some(ms) => format!("{:>7.1}", ms),
+        None => format!("{:>7}", "-"),
+    }
+}
+
+fn fmt_loss(snap: &Option<HopSnapshot>) -> String {
+    match snap {
+        Some(s) => format!("{:>5.1}", s.loss_pct),
+        None => format!("{:>5}", "-"),
+    }
+}
+
+/// Write a human-readable diff report
+pub fn write_diff_text<W: Write>(diff: &SessionDiff, mut w: W, color: bool) -> Result<()> {
+    let p = Palette { color };
+
+    let target = if diff.target_before == diff.target_after {
+        sanitize_display(&diff.target_before)
+    } else {
+        format!(
+            "{} vs {}",
+            sanitize_display(&diff.target_before),
+            sanitize_display(&diff.target_after)
+        )
+    };
+    writeln!(w, "Trace diff: {}", target)?;
+    writeln!(
+        w,
+        "  before: {}  ({})",
+        sanitize_display(&diff.before_file),
+        diff.started_before.format("%Y-%m-%d %H:%M:%S UTC")
+    )?;
+    writeln!(
+        w,
+        "  after:  {}  ({})",
+        sanitize_display(&diff.after_file),
+        diff.started_after.format("%Y-%m-%d %H:%M:%S UTC")
+    )?;
+    writeln!(w)?;
+
+    // Host column width: fits the longest label on either side
+    let host_w = diff
+        .hops
+        .iter()
+        .flat_map(|h| {
+            [
+                host_label(&h.before).chars().count(),
+                host_label(&h.after).chars().count(),
+            ]
+        })
+        .max()
+        .unwrap_or(15)
+        .max(15);
+
+    writeln!(
+        w,
+        " TTL  {:<hw$}  {:<hw$}  {:<8}  {:>15}  {:>13}",
+        "Before",
+        "After",
+        "Change",
+        "Avg RTT (ms)",
+        "Loss (%)",
+        hw = host_w
+    )?;
+
+    for hop in &diff.hops {
+        let (marker, painted_marker) = match hop.change {
+            HopChange::Unchanged => ("", String::new()),
+            HopChange::PathChange => ("[path]", p.yellow("[path]")),
+            HopChange::Added => ("[added]", p.green("[added]")),
+            HopChange::Lost => ("[lost]", p.red("[lost]")),
+        };
+        // Pad based on the unpainted marker (ANSI codes have zero display width)
+        let marker_cell = format!("{}{}", painted_marker, " ".repeat(8 - marker.len()));
+
+        let rtt_cell = {
+            let cell = format!(
+                "{} \u{2192} {}",
+                fmt_rtt(hop.before.as_ref().and_then(|s| s.avg_rtt_ms)),
+                fmt_rtt(hop.after.as_ref().and_then(|s| s.avg_rtt_ms))
+            );
+            if hop.rtt_significant {
+                p.yellow(&cell)
+            } else {
+                cell
+            }
+        };
+        let loss_cell = format!(
+            "{} \u{2192} {}",
+            fmt_loss(&hop.before),
+            fmt_loss(&hop.after)
+        );
+
+        let before_label = host_label(&hop.before);
+        let after_label = host_label(&hop.after);
+        writeln!(
+            w,
+            " {:>3}  {:<hw$}  {:<hw$}  {}  {}  {}",
+            hop.ttl,
+            before_label,
+            after_label,
+            marker_cell,
+            rtt_cell,
+            loss_cell,
+            hw = host_w
+        )?;
+
+        // ECMP responder-set changes (beyond the primary)
+        if !hop.responders_added.is_empty() || !hop.responders_removed.is_empty() {
+            let mut parts = Vec::new();
+            for ip in &hop.responders_added {
+                parts.push(p.green(&format!("+{}", ip)));
+            }
+            for ip in &hop.responders_removed {
+                parts.push(p.red(&format!("-{}", ip)));
+            }
+            writeln!(w, "      responders: {}", parts.join("  "))?;
+        }
+    }
+
+    writeln!(w)?;
+
+    let path_changes = diff.count(HopChange::PathChange);
+    let added = diff.count(HopChange::Added);
+    let lost = diff.count(HopChange::Lost);
+    let rtt_shifts = diff.rtt_shifts();
+
+    if diff.has_changes() {
+        writeln!(
+            w,
+            "Summary: {} path change(s), {} hop(s) added, {} hop(s) lost, {} significant latency shift(s)",
+            path_changes, added, lost, rtt_shifts
+        )?;
+    } else {
+        writeln!(w, "Summary: {}", p.dim("no changes detected"))?;
+    }
+
+    let dest = match (diff.complete_before, diff.complete_after) {
+        (true, true) => {
+            let hops_before = diff
+                .dest_ttl_before
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "?".into());
+            let hops_after = diff
+                .dest_ttl_after
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "?".into());
+            format!(
+                "destination reached in both ({} \u{2192} {} hops)",
+                hops_before, hops_after
+            )
+        }
+        (true, false) => p.red("destination reached only in before session"),
+        (false, true) => p.green("destination reached only in after session"),
+        (false, false) => p.dim("destination not reached in either session"),
+    };
+    writeln!(w, "  {}", dest)?;
+
+    Ok(())
+}
+
+/// Write the diff as pretty-printed JSON
+pub fn write_diff_json<W: Write>(diff: &SessionDiff, writer: W) -> Result<()> {
+    serde_json::to_writer_pretty(writer, diff)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::state::Target;
+    use std::net::Ipv4Addr;
+    use std::time::Duration;
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, last))
+    }
+
+    fn session_with_hops(hops: &[(u8, IpAddr, u64)]) -> Session {
+        let target = Target::new("test.example".to_string(), ip(99));
+        let mut session = Session::new(target, Config::default());
+        for &(ttl, addr, rtt_ms) in hops {
+            if let Some(hop) = session.hop_mut(ttl) {
+                hop.record_sent();
+                hop.record_response(addr, Duration::from_millis(rtt_ms));
+            }
+        }
+        session
+    }
+
+    #[test]
+    fn test_diff_no_changes() {
+        let a = session_with_hops(&[(1, ip(1), 5), (2, ip(2), 10)]);
+        let b = session_with_hops(&[(1, ip(1), 5), (2, ip(2), 10)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert_eq!(diff.hops.len(), 2);
+        assert!(!diff.has_changes());
+        assert!(
+            diff.hops
+                .iter()
+                .all(|h| h.change == HopChange::Unchanged && !h.rtt_significant)
+        );
+    }
+
+    #[test]
+    fn test_diff_path_change() {
+        let a = session_with_hops(&[(1, ip(1), 5), (2, ip(2), 10)]);
+        let b = session_with_hops(&[(1, ip(1), 5), (2, ip(3), 10)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert_eq!(diff.count(HopChange::PathChange), 1);
+        let changed = &diff.hops[1];
+        assert_eq!(changed.ttl, 2);
+        assert_eq!(changed.change, HopChange::PathChange);
+        assert_eq!(changed.responders_added, vec![ip(3)]);
+        assert_eq!(changed.responders_removed, vec![ip(2)]);
+    }
+
+    #[test]
+    fn test_diff_added_and_lost_hops() {
+        let a = session_with_hops(&[(1, ip(1), 5), (3, ip(3), 15)]);
+        let b = session_with_hops(&[(1, ip(1), 5), (2, ip(2), 10)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert_eq!(diff.count(HopChange::Added), 1);
+        assert_eq!(diff.count(HopChange::Lost), 1);
+        let added = diff.hops.iter().find(|h| h.ttl == 2).unwrap();
+        assert_eq!(added.change, HopChange::Added);
+        assert!(added.before.is_none());
+        let lost = diff.hops.iter().find(|h| h.ttl == 3).unwrap();
+        assert_eq!(lost.change, HopChange::Lost);
+        assert!(lost.after.is_none());
+    }
+
+    #[test]
+    fn test_diff_skips_silent_hops() {
+        let a = session_with_hops(&[(1, ip(1), 5), (5, ip(5), 25)]);
+        let b = session_with_hops(&[(1, ip(1), 5), (5, ip(5), 25)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        // TTLs 2-4 never responded in either session: not reported
+        let ttls: Vec<u8> = diff.hops.iter().map(|h| h.ttl).collect();
+        assert_eq!(ttls, vec![1, 5]);
+    }
+
+    #[test]
+    fn test_diff_rtt_significance() {
+        // 10ms -> 100ms: significant (abs 90ms >= 5ms, rel 900% >= 20%)
+        let a = session_with_hops(&[(1, ip(1), 10)]);
+        let b = session_with_hops(&[(1, ip(1), 100)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert!(diff.hops[0].rtt_significant);
+        assert!((diff.hops[0].avg_rtt_delta_ms.unwrap() - 90.0).abs() < 0.5);
+        assert!(diff.has_changes());
+
+        // 100ms -> 104ms: not significant (abs 4ms < 5ms)
+        let a = session_with_hops(&[(1, ip(1), 100)]);
+        let b = session_with_hops(&[(1, ip(1), 104)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert!(!diff.hops[0].rtt_significant);
+
+        // 100ms -> 110ms: not significant (rel 10% < 20%)
+        let a = session_with_hops(&[(1, ip(1), 100)]);
+        let b = session_with_hops(&[(1, ip(1), 110)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        assert!(!diff.hops[0].rtt_significant);
+    }
+
+    #[test]
+    fn test_diff_ecmp_responder_set_change() {
+        let mut a = session_with_hops(&[(1, ip(1), 5)]);
+        if let Some(hop) = a.hop_mut(1) {
+            hop.record_sent();
+            hop.record_response(ip(1), Duration::from_millis(5));
+            hop.record_sent();
+            hop.record_response(ip(7), Duration::from_millis(6));
+        }
+        let b = session_with_hops(&[(1, ip(1), 5)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        // Primary unchanged but responder 10.0.0.7 disappeared
+        assert_eq!(diff.hops[0].change, HopChange::Unchanged);
+        assert_eq!(diff.hops[0].responders_removed, vec![ip(7)]);
+        assert!(diff.has_changes());
+    }
+
+    #[test]
+    fn test_diff_text_output() {
+        let a = session_with_hops(&[(1, ip(1), 5), (2, ip(2), 10)]);
+        let b = session_with_hops(&[(1, ip(1), 5), (2, ip(3), 10), (3, ip(4), 20)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        let mut out = Vec::new();
+        write_diff_text(&diff, &mut out, false).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("Trace diff: test.example"));
+        assert!(text.contains("[path]"));
+        assert!(text.contains("[added]"));
+        assert!(text.contains("1 path change(s), 1 hop(s) added, 0 hop(s) lost"));
+        // No ANSI escapes when color is off
+        assert!(!text.contains('\x1b'));
+    }
+
+    #[test]
+    fn test_diff_json_output_roundtrips() {
+        let a = session_with_hops(&[(1, ip(1), 5)]);
+        let b = session_with_hops(&[(1, ip(2), 5)]);
+        let diff = diff_sessions(&a, &b, "a.json", "b.json");
+        let mut out = Vec::new();
+        write_diff_json(&diff, &mut out).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed["hops"][0]["change"], "path_change");
+    }
+}

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,7 +1,11 @@
 pub mod csv;
+pub mod diff;
 pub mod json;
 pub mod report;
+pub mod stream;
 
 pub use csv::*;
+pub use diff::*;
 pub use json::*;
 pub use report::*;
+pub use stream::*;

--- a/src/export/stream.rs
+++ b/src/export/stream.rs
@@ -1,0 +1,126 @@
+//! Line-delimited JSON event streaming for --stream-json mode.
+//!
+//! Each probe event is emitted as one JSON object per line, matching the
+//! event schema used in saved session files (offset_ms/ttl/seq/flow_id plus
+//! a flattened outcome tagged by "type"), with the target IP added so
+//! multi-target streams can be demultiplexed with jq/grep.
+
+use crate::state::{ProbeEvent, Session};
+use anyhow::Result;
+use serde::Serialize;
+use std::io::Write;
+use std::net::IpAddr;
+
+/// A probe event tagged with its target
+#[derive(Serialize)]
+struct EventLine<'a> {
+    target: IpAddr,
+    #[serde(flatten)]
+    event: &'a ProbeEvent,
+}
+
+/// Per-target summary emitted when the stream ends
+#[derive(Serialize)]
+struct SummaryLine {
+    target: IpAddr,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    complete: bool,
+    dest_ttl: Option<u8>,
+    total_sent: u64,
+    hops_responding: usize,
+}
+
+/// Write one probe event as a JSON line
+pub fn write_event_line<W: Write>(mut w: W, target: IpAddr, event: &ProbeEvent) -> Result<()> {
+    serde_json::to_writer(&mut w, &EventLine { target, event })?;
+    writeln!(w)?;
+    Ok(())
+}
+
+/// Write the end-of-stream summary for a target as a JSON line
+pub fn write_summary_line<W: Write>(mut w: W, target: IpAddr, session: &Session) -> Result<()> {
+    let line = SummaryLine {
+        target,
+        kind: "summary",
+        complete: session.complete,
+        dest_ttl: session.dest_ttl,
+        total_sent: session.total_sent,
+        hops_responding: session.hops.iter().filter(|h| h.received > 0).count(),
+    };
+    serde_json::to_writer(&mut w, &line)?;
+    writeln!(w)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::state::{ProbeOutcome, Target};
+    use std::net::Ipv4Addr;
+
+    fn target_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
+    }
+
+    #[test]
+    fn test_event_line_reply_schema() {
+        let event = ProbeEvent {
+            offset_ms: 1234,
+            ttl: 5,
+            seq: 2,
+            flow_id: 0,
+            outcome: ProbeOutcome::Reply {
+                addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                rtt_us: 12500,
+            },
+        };
+        let mut out = Vec::new();
+        write_event_line(&mut out, target_ip(), &event).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.ends_with('\n'));
+        assert_eq!(text.lines().count(), 1);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["target"], "8.8.8.8");
+        assert_eq!(v["type"], "reply");
+        assert_eq!(v["ttl"], 5);
+        assert_eq!(v["offset_ms"], 1234);
+        assert_eq!(v["addr"], "10.0.0.1");
+        assert_eq!(v["rtt_us"], 12500);
+    }
+
+    #[test]
+    fn test_event_line_timeout_schema() {
+        let event = ProbeEvent {
+            offset_ms: 5000,
+            ttl: 3,
+            seq: 7,
+            flow_id: 1,
+            outcome: ProbeOutcome::Timeout,
+        };
+        let mut out = Vec::new();
+        write_event_line(&mut out, target_ip(), &event).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["type"], "timeout");
+        assert_eq!(v["flow_id"], 1);
+        assert!(v.get("addr").is_none());
+    }
+
+    #[test]
+    fn test_summary_line_schema() {
+        let target = Target::new("8.8.8.8".to_string(), target_ip());
+        let mut session = Session::new(target, Config::default());
+        session.complete = true;
+        session.dest_ttl = Some(13);
+        session.total_sent = 42;
+        let mut out = Vec::new();
+        write_summary_line(&mut out, target_ip(), &session).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["type"], "summary");
+        assert_eq!(v["complete"], true);
+        assert_eq!(v["dest_ttl"], 13);
+        assert_eq!(v["total_sent"], 42);
+        assert_eq!(v["hops_responding"], 0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ mod update;
 
 use cli::Args;
 use config::{Config, ProbeProtocol};
-use export::{export_csv, export_json, generate_report};
+use export::{
+    diff_sessions, export_csv, export_json, generate_report, write_diff_json, write_diff_text,
+    write_event_line, write_summary_line,
+};
 use lookup::asn::{AsnLookup, run_asn_worker};
 use lookup::geo::{GeoLookup, run_geo_worker};
 use lookup::ix::{IxLookup, run_ix_worker};
@@ -51,6 +54,11 @@ async fn main() -> Result<()> {
     // Handle replay mode (quick viewing operation, no update check)
     if let Some(ref replay_path) = args.replay {
         return run_replay_mode(&args, replay_path).await;
+    }
+
+    // Handle diff mode (compare two saved sessions, no probing)
+    if let Some(ref diff_files) = args.diff {
+        return run_diff_mode(&diff_files[0], &diff_files[1], args.json);
     }
 
     // Spawn background update check after early exits
@@ -314,7 +322,7 @@ async fn main() -> Result<()> {
             resolve_info,
         )
         .await
-    } else if args.no_tui {
+    } else if args.no_tui || args.stream_json {
         run_streaming_mode(
             args,
             sessions,
@@ -404,20 +412,45 @@ fn config_for_target_effective_flows(
 fn load_session(path: &str) -> Result<Session> {
     const MAX_REPLAY_SIZE: u64 = 10 * 1024 * 1024; // 10MB
 
-    let file = File::open(path).with_context(|| format!("Failed to open replay file: {}", path))?;
+    let file =
+        File::open(path).with_context(|| format!("Failed to open session file: {}", path))?;
 
     // Check file size to prevent DoS via huge JSON
     let metadata = file
         .metadata()
-        .with_context(|| format!("Failed to read replay file metadata: {}", path))?;
+        .with_context(|| format!("Failed to read session file metadata: {}", path))?;
     if metadata.len() > MAX_REPLAY_SIZE {
-        anyhow::bail!("Replay file too large (max 10MB): {}", path);
+        anyhow::bail!("Session file too large (max 10MB): {}", path);
     }
 
     let reader = BufReader::new(file);
     let session: Session = serde_json::from_reader(reader)
-        .with_context(|| format!("Failed to parse replay file: {}", path))?;
+        .with_context(|| format!("Failed to parse session file: {}", path))?;
     Ok(session)
+}
+
+/// Run diff mode - compare two saved sessions and print the differences
+fn run_diff_mode(before_path: &str, after_path: &str, json: bool) -> Result<()> {
+    let before = load_session(before_path)?;
+    let after = load_session(after_path)?;
+
+    if before.target.resolved != after.target.resolved {
+        eprintln!(
+            "Warning: sessions trace different targets ({} vs {})",
+            before.target.resolved, after.target.resolved
+        );
+    }
+
+    let diff = diff_sessions(&before, &after, before_path, after_path);
+    let stdout = std::io::stdout();
+    if json {
+        write_diff_json(&diff, stdout.lock())?;
+        println!();
+    } else {
+        let color = is_terminal::is_terminal(std::io::stdout());
+        write_diff_text(&diff, stdout.lock(), color)?;
+    }
+    Ok(())
 }
 
 /// Run replay mode - load a saved session and display/export it
@@ -1256,6 +1289,7 @@ async fn run_streaming_mode(
     let ratelimit_handle = tokio::spawn(run_ratelimit_worker(sessions.clone(), cancel.clone()));
 
     // Print results as they come in
+    let stream_json = args.stream_json;
     let mut last_total_received: HashMap<IpAddr, u64> = HashMap::new();
     let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
 
@@ -1265,6 +1299,10 @@ async fn run_streaming_mode(
                 break;
             }
             _ = interval.tick() => {
+                if stream_json {
+                    emit_stream_events(&sessions, &targets)?;
+                    continue;
+                }
                 let sessions_read = sessions.read();
                 for target_ip in &targets {
                     if let Some(state) = sessions_read.get(target_ip) {
@@ -1335,6 +1373,49 @@ async fn run_streaming_mode(
     ratelimit_handle.await?;
     shutdown_log("streaming ratelimit worker joined");
 
+    // Final drain: emit events recorded between loop exit and receiver join,
+    // then a per-target summary line
+    if stream_json {
+        emit_stream_events(&sessions, &targets)?;
+        let mut out = std::io::stdout().lock();
+        let sessions_read = sessions.read();
+        for target_ip in &targets {
+            if let Some(state) = sessions_read.get(target_ip) {
+                write_summary_line(&mut out, *target_ip, &state.read())?;
+            }
+        }
+        std::io::Write::flush(&mut out)?;
+    }
+
+    Ok(())
+}
+
+/// Drain newly recorded probe events from each session and emit them as
+/// line-delimited JSON on stdout. Draining (rather than indexing) keeps
+/// memory bounded for long-running streams; nothing else consumes events
+/// in stream mode (--stream-json conflicts with batch --json export).
+fn emit_stream_events(sessions: &SessionMap, targets: &[IpAddr]) -> Result<()> {
+    let mut out = std::io::stdout().lock();
+    let mut wrote = false;
+    let sessions_read = sessions.read();
+    for target_ip in targets {
+        if let Some(state) = sessions_read.get(target_ip) {
+            let events: Vec<_> = {
+                let mut session = state.write();
+                if session.events.is_empty() {
+                    continue;
+                }
+                session.events.drain(..).collect()
+            };
+            for event in &events {
+                write_event_line(&mut out, *target_ip, event)?;
+            }
+            wrote = true;
+        }
+    }
+    if wrote {
+        std::io::Write::flush(&mut out)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implements the full **Trace Diffing & Streaming** section of the roadmap as the v0.20 theme.

### Trace diffing (`--diff before.json after.json`)

- Compares two saved sessions hop by hop: `[path]` markers for primary-responder changes, `[added]`/`[lost]` for hop presence, and `+ip`/`-ip` detail lines for ECMP responder-set churn
- Avg RTT and loss shown side by side; latency shifts highlighted when >=5ms **and** >=20% of the before value
- Summary line with change counts and destination reachability; ANSI color when stdout is a terminal
- `--diff ... --json` emits the whole diff as machine-readable JSON
- Warns when the two sessions trace different targets

### Streaming JSON (`--stream-json`)

- One JSON line per probe event (`reply`/`timeout`/`late_reply`), same schema as the `events` array in saved session files plus a `target` field for demultiplexing multi-target runs
- Final `summary` line per target (`complete`, `dest_ttl`, `total_sent`, `hops_responding`)
- Implies `--no-tui`; conflicts with batch output flags; works with `-c` or until Ctrl-C
- Events are drained rather than indexed, keeping memory bounded for long-running monitoring pipelines; a final drain after receiver join catches late replies

## Implementation notes

- New `src/export/diff.rs` and `src/export/stream.rs` follow the existing export-module conventions (generic `Write` sinks, re-exported from `export::`)
- `--diff` early-exits in `main()` like `--replay` (no sockets, no permissions needed); `load_session` error messages generalized from "replay file" to "session file"
- External strings (hostnames, file paths) routed through `sanitize_display` before terminal output

## Testing

- 16 new tests (240 total passing): diff classification (path change, added/lost, silent-hop skipping, RTT significance thresholds, ECMP responder churn), NDJSON line schemas, CLI conflict matrix
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean
- Manually verified: `--diff` text + JSON output against generated fixtures (piped through `jq`); `--stream-json` live against localhost with finite `-c` runs, infinite runs ended via SIGINT (graceful summary emission), and jq filter composability