### PR TITLE
Add daemon mode, Prometheus exporter, and official Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.github/
+docs/
+tests/
+*.md
+.pre-commit-config.yaml
+install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Daemon mode** (`--daemon`): headless probing with no per-hop stdout, for container/monitoring deployments. Combine with `--prometheus` and/or `--stream-json` to consume the data.
+- **Prometheus exporter** (`--prometheus <ADDR>`, e.g. `:9090`): OpenMetrics endpoint with per-hop sent/response/timeout counters, RTT avg/min/max/stddev gauges, loss ratio, ECMP responder count, hop identity info series, and per-target reachability/path-length metrics. Includes `GET /healthz` for container orchestration. Hand-rolled over the existing tokio runtime — no new dependencies.
+- **SIGTERM handling**: `docker stop` now triggers the same graceful shutdown as Ctrl-C (unix).
+- **Official Dockerfile**: multi-stage Alpine/musl build producing a minimal image; `.dockerignore` included.
 - **Trace diffing** (`--diff before.json after.json`): compare two saved sessions hop by hop. Reports path changes (primary responder differs), added/lost hops, ECMP responder-set changes, avg RTT deltas (highlighted when ≥5ms and ≥20%), loss changes, and destination reachability. `--json` emits the diff as machine-readable JSON.
 - **Streaming JSON output** (`--stream-json`): emit each probe event (reply/timeout/late_reply) as one line of JSON on stdout for piping to jq/grep/monitoring pipelines. Event lines match the saved-session `events` schema with a `target` field added; a per-target `summary` line is emitted at end of stream. Implies `--no-tui`; memory stays bounded on infinite runs.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build stage: static musl binary (matches the MSRV in Cargo.toml)
+FROM rust:1.88-alpine AS build
+RUN apk add --no-cache musl-dev
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release --locked
+
+# Runtime stage: minimal image with CA certificates for ASN/IX/update lookups
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=build /src/target/release/ttl /usr/local/bin/ttl
+
+# ttl needs CAP_NET_RAW for ICMP sockets. Docker grants NET_RAW by default;
+# stricter runtimes need: --cap-add NET_RAW
+ENTRYPOINT ["ttl"]
+CMD ["--help"]
+
+# Example healthcheck when running with --prometheus :9090
+# (uncomment, or set in compose/orchestration):
+# HEALTHCHECK --interval=30s --timeout=3s \
+#   CMD wget -qO- http://127.0.0.1:9090/healthz || exit 1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ See [Installation](#installation) below for setup instructions.
 - **Update notifications** - in-app banner when new versions are available
 - **Scriptable** - JSON, CSV, text report, and line-delimited JSON streaming output
 - **Trace diffing** - compare two saved sessions for path and latency changes
+- **Daemon mode + Prometheus exporter** - headless continuous monitoring with `/metrics` and `/healthz`
+- **Docker-ready** - official Dockerfile, graceful SIGTERM shutdown
 
 See [docs/FEATURES.md](docs/FEATURES.md) for detailed documentation, including optional setup for [GeoIP](docs/FEATURES.md#geoip-location) and [IX detection](docs/FEATURES.md#ix-detection).
 
@@ -193,6 +195,7 @@ ttl 1.1.1.1 -c 100 --json      # JSON export
 ttl 1.1.1.1 -c 100 --csv       # CSV export
 ttl 1.1.1.1 --stream-json      # Stream events as line-delimited JSON
 ttl --diff before.json after.json    # Compare two saved sessions
+ttl --daemon --prometheus :9090 1.1.1.1   # Headless + Prometheus metrics
 ttl --replay results.json      # Replay saved session
 ttl --replay results.json --animate  # Animated replay
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,10 +125,10 @@
 
 **Why this matters:** Containerized infrastructure needs lightweight, headless traceroute for continuous path monitoring and integration with Prometheus/Grafana.
 
-- [ ] Official Dockerfile (minimal image, NET_RAW capability)
-- [ ] `--daemon` mode (no TUI, lightweight, signal handling)
-- [ ] Prometheus/OpenMetrics exporter (`--prometheus :9090`)
-- [ ] Health check endpoint for container orchestration
+- [x] Official Dockerfile (minimal image, NET_RAW capability)
+- [x] `--daemon` mode (no TUI, lightweight, SIGINT/SIGTERM handling)
+- [x] Prometheus/OpenMetrics exporter (`--prometheus :9090`)
+- [x] Health check endpoint for container orchestration (`/healthz`)
 
 ### Interactive Target Selection
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -549,6 +549,61 @@ Summary: 1 path change(s), 0 hop(s) added, 1 hop(s) lost, 0 significant latency 
   destination reached in both (5 → 5 hops)
 ```
 
+### Daemon Mode & Prometheus Exporter
+
+```bash
+ttl --daemon --prometheus :9090 8.8.8.8      # Headless, metrics on :9090
+ttl --daemon --prometheus 127.0.0.1:9100 host1 host2
+ttl --daemon --stream-json host | jq .       # Daemon + event stream
+```
+
+`--daemon` runs headless with no per-hop stdout — probing continues until
+`-c` rounds complete or SIGINT/SIGTERM. Combine with `--prometheus` and/or
+`--stream-json` to consume the data. `docker stop` (SIGTERM) triggers the
+same graceful shutdown as Ctrl-C.
+
+`--prometheus <ADDR>` serves an OpenMetrics endpoint (`:9090` binds all
+interfaces). Endpoints:
+
+- `GET /metrics` — Prometheus exposition format
+- `GET /healthz` — returns `200 ok` for container orchestration
+
+Exported metrics (labels: `target` = resolved IP, `host` = name as given,
+`ttl` = hop number):
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `ttl_probes_sent_total` | counter | Probes sent per hop |
+| `ttl_responses_total` | counter | Responses received per hop |
+| `ttl_timeouts_total` | counter | Timeouts per hop |
+| `ttl_loss_ratio` | gauge | Loss ratio per hop (0–1) |
+| `ttl_rtt_avg_seconds` / `min` / `max` / `stddev` | gauge | RTT stats for the hop's primary responder |
+| `ttl_hop_responders` | gauge | Distinct responder IPs at the hop (ECMP) |
+| `ttl_hop_info` | gauge | Primary responder identity (`ip`, `hostname` labels, value 1) |
+| `ttl_target_reachable` | gauge | Destination responded (1/0) |
+| `ttl_path_hops` | gauge | Hop count to destination |
+| `ttl_target_probes_total` | counter | Completed probes across all hops |
+
+### Docker
+
+```bash
+docker build -t ttl .
+docker run --rm -it ttl 8.8.8.8                          # Interactive TUI
+docker run -d -p 9090:9090 ttl --daemon --prometheus :9090 8.8.8.8
+curl localhost:9090/metrics
+```
+
+The image is Alpine-based with a static musl binary. Docker grants
+`CAP_NET_RAW` by default; stricter runtimes (Kubernetes, podman) may need it
+added explicitly:
+
+```yaml
+# Kubernetes
+securityContext:
+  capabilities:
+    add: ["NET_RAW"]
+```
+
 ### Session Replay
 
 ```bash
@@ -617,6 +672,8 @@ Options:
       --json             JSON output (requires -c)
       --csv              CSV output (requires -c)
       --stream-json      Stream probe events as line-delimited JSON (implies --no-tui)
+      --daemon           Headless mode, no per-hop output (for --prometheus/--stream-json)
+      --prometheus <ADDR> Serve Prometheus metrics + /healthz (e.g. :9090; implies --no-tui)
       --diff <BEFORE> <AFTER>  Compare two saved sessions (with --json for JSON output)
       --replay <FILE>    Replay a saved JSON session
       --animate          Animate replay (show probe-by-probe discovery)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,9 @@ EXAMPLES:
         ttl --stream-json host | jq .   # Line-delimited JSON events
         ttl --diff before.json after.json
 
+    Continuous monitoring:
+        ttl --daemon --prometheus :9090 host   # Headless + metrics endpoint
+
 DETECTION INDICATORS:
     [NAT]  - Source port rewriting detected (affects multi-flow accuracy)
     [RL?]  - Router rate-limiting ICMP (loss may be artificial)
@@ -152,6 +155,14 @@ pub struct Args {
     #[arg(long = "stream-json", conflicts_with_all = ["json", "csv", "report", "replay", "diff"])]
     pub stream_json: bool,
 
+    /// Daemon mode: headless, no per-hop output (combine with --prometheus or --stream-json)
+    #[arg(long = "daemon", conflicts_with_all = ["json", "csv", "report", "replay", "diff"])]
+    pub daemon: bool,
+
+    /// Serve Prometheus/OpenMetrics on this address (e.g. :9090 or 127.0.0.1:9090; implies --no-tui)
+    #[arg(long = "prometheus", value_name = "ADDR", conflicts_with_all = ["json", "csv", "report", "replay", "diff"])]
+    pub prometheus: Option<String>,
+
     /// Color theme (default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized)
     #[arg(long = "theme", default_value = "default")]
     pub theme: String,
@@ -214,6 +225,22 @@ impl Args {
     /// Check if running in batch mode (non-interactive)
     pub fn is_batch_mode(&self) -> bool {
         self.json || self.csv || self.report
+    }
+
+    /// Check if running headless (no TUI)
+    pub fn is_headless(&self) -> bool {
+        self.no_tui || self.stream_json || self.daemon || self.prometheus.is_some()
+    }
+
+    /// Parse the --prometheus listen address; ":9090" binds all interfaces
+    pub fn prometheus_addr(&self) -> Option<std::net::SocketAddr> {
+        let addr = self.prometheus.as_deref()?;
+        let full = if addr.starts_with(':') {
+            format!("0.0.0.0{}", addr)
+        } else {
+            addr.to_string()
+        };
+        full.parse().ok()
     }
 
     /// Validate arguments
@@ -291,6 +318,16 @@ impl Args {
             return Err("Replay speed must be between 0.1 and 1000.0".into());
         }
 
+        // Validate prometheus listen address early (":9090" means all interfaces)
+        if let Some(ref addr) = self.prometheus
+            && self.prometheus_addr().is_none()
+        {
+            return Err(format!(
+                "Invalid --prometheus address: {} (use :9090 or 127.0.0.1:9090)",
+                addr
+            ));
+        }
+
         // Validate interface name
         if let Some(ref iface) = self.interface {
             if iface.is_empty() {
@@ -339,6 +376,8 @@ mod tests {
             speed: 10.0,
             diff: None,
             stream_json: false,
+            daemon: false,
+            prometheus: None,
             theme: "default".to_string(),
             wide: false,
             interface: None,
@@ -439,5 +478,53 @@ mod tests {
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--json", "8.8.8.8"]).is_err());
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--csv", "8.8.8.8"]).is_err());
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--report", "8.8.8.8"]).is_err());
+    }
+
+    #[test]
+    fn test_prometheus_addr_shorthand() {
+        let args = make_args(|a| a.prometheus = Some(":9090".to_string()));
+        assert_eq!(
+            args.prometheus_addr(),
+            Some("0.0.0.0:9090".parse().unwrap())
+        );
+        assert!(args.validate().is_ok());
+        assert!(args.is_headless());
+    }
+
+    #[test]
+    fn test_prometheus_addr_full() {
+        let args = make_args(|a| a.prometheus = Some("127.0.0.1:9100".to_string()));
+        assert_eq!(
+            args.prometheus_addr(),
+            Some("127.0.0.1:9100".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_prometheus_addr_invalid() {
+        let args = make_args(|a| a.prometheus = Some("not-an-addr".to_string()));
+        assert!(args.prometheus_addr().is_none());
+        assert!(args.validate().unwrap_err().contains("--prometheus"));
+    }
+
+    #[test]
+    fn test_daemon_conflicts_with_batch_output() {
+        assert!(Args::try_parse_from(["ttl", "--daemon", "--json", "8.8.8.8"]).is_err());
+        assert!(Args::try_parse_from(["ttl", "--daemon", "--replay", "x.json"]).is_err());
+    }
+
+    #[test]
+    fn test_daemon_composes_with_stream_json_and_prometheus() {
+        let args = Args::try_parse_from([
+            "ttl",
+            "--daemon",
+            "--stream-json",
+            "--prometheus",
+            ":9090",
+            "8.8.8.8",
+        ])
+        .unwrap();
+        assert!(args.daemon && args.stream_json);
+        assert!(args.is_headless());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod cli;
 mod config;
 mod export;
 mod lookup;
+mod metrics;
 mod prefs;
 mod probe;
 mod state;
@@ -322,7 +323,7 @@ async fn main() -> Result<()> {
             resolve_info,
         )
         .await
-    } else if args.no_tui || args.stream_json {
+    } else if args.is_headless() {
         run_streaming_mode(
             args,
             sessions,
@@ -1288,8 +1289,33 @@ async fn run_streaming_mode(
     // Spawn rate limit detection worker (always enabled, lightweight analysis)
     let ratelimit_handle = tokio::spawn(run_ratelimit_worker(sessions.clone(), cancel.clone()));
 
+    // Bind the Prometheus exporter up front so bind errors fail fast
+    let metrics_handle = if let Some(addr) = args.prometheus_addr() {
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .with_context(|| format!("Failed to bind Prometheus exporter on {}", addr))?;
+        eprintln!(
+            "Prometheus exporter listening on http://{}/metrics",
+            listener.local_addr()?
+        );
+        Some(tokio::spawn(metrics::run_metrics_server(
+            listener,
+            sessions.clone(),
+            cancel.clone(),
+        )))
+    } else {
+        None
+    };
+
     // Print results as they come in
     let stream_json = args.stream_json;
+    let daemon = args.daemon;
+    if daemon && !stream_json && metrics_handle.is_none() {
+        eprintln!(
+            "Warning: --daemon without --prometheus or --stream-json produces no output; \
+             probing continues but results are not observable."
+        );
+    }
     let mut last_total_received: HashMap<IpAddr, u64> = HashMap::new();
     let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
 
@@ -1301,6 +1327,11 @@ async fn run_streaming_mode(
             _ = interval.tick() => {
                 if stream_json {
                     emit_stream_events(&sessions, &targets)?;
+                    continue;
+                }
+                if daemon {
+                    // Daemon mode: no per-hop stdout; data is consumed via
+                    // --prometheus or --stream-json
                     continue;
                 }
                 let sessions_read = sessions.read();
@@ -1373,6 +1404,12 @@ async fn run_streaming_mode(
     ratelimit_handle.await?;
     shutdown_log("streaming ratelimit worker joined");
 
+    if let Some(handle) = metrics_handle {
+        shutdown_log("streaming waiting for metrics server");
+        handle.await?;
+        shutdown_log("streaming metrics server joined");
+    }
+
     // Final drain: emit events recorded between loop exit and receiver join,
     // then a per-target summary line
     if stream_json {
@@ -1434,19 +1471,52 @@ fn generate_completions(shell: &str) {
     generate(shell, &mut cmd, "ttl", &mut std::io::stdout());
 }
 
+/// Install a handler that cancels on Ctrl+C (SIGINT) and, on unix, SIGTERM —
+/// the signal container runtimes send on `docker stop`.
 fn install_ctrlc_handler(cancel: CancellationToken) {
     tokio::spawn(async move {
+        #[cfg(unix)]
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
+
         loop {
-            if tokio::signal::ctrl_c().await.is_err() {
-                break;
-            }
+            #[cfg(unix)]
+            let signal_name = {
+                let sigterm_recv = async {
+                    match sigterm.as_mut() {
+                        Some(s) => {
+                            s.recv().await;
+                        }
+                        None => std::future::pending().await,
+                    }
+                };
+                tokio::select! {
+                    result = tokio::signal::ctrl_c() => {
+                        if result.is_err() {
+                            break;
+                        }
+                        "Ctrl+C"
+                    }
+                    _ = sigterm_recv => "SIGTERM",
+                }
+            };
+            #[cfg(not(unix))]
+            let signal_name = {
+                if tokio::signal::ctrl_c().await.is_err() {
+                    break;
+                }
+                "Ctrl+C"
+            };
 
             if cancel.is_cancelled() {
-                eprintln!("Ctrl+C during shutdown, forcing exit.");
+                eprintln!("{} during shutdown, forcing exit.", signal_name);
                 std::process::exit(130);
             }
 
-            eprintln!("Ctrl+C received, shutting down (press Ctrl+C again to force exit).");
+            eprintln!(
+                "{} received, shutting down (repeat to force exit).",
+                signal_name
+            );
             cancel.cancel();
         }
     });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,381 @@
+//! Prometheus/OpenMetrics exporter for --prometheus mode.
+//!
+//! Serves a hand-rolled HTTP/1.1 endpoint (GET /metrics, GET /healthz) over a
+//! tokio listener — deliberately no HTTP framework dependency; the exposition
+//! format is plain text and the routing is two paths.
+
+use crate::lookup::sanitize_display;
+use crate::trace::receiver::SessionMap;
+use anyhow::{Context, Result};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+
+/// Metric definitions in output order: (name, type, help)
+const METRICS: &[(&str, &str, &str)] = &[
+    (
+        "ttl_probes_sent_total",
+        "counter",
+        "Probes sent to this hop",
+    ),
+    (
+        "ttl_responses_total",
+        "counter",
+        "Responses received from this hop",
+    ),
+    (
+        "ttl_timeouts_total",
+        "counter",
+        "Probes that timed out at this hop",
+    ),
+    (
+        "ttl_loss_ratio",
+        "gauge",
+        "Loss ratio at this hop (0-1, completed probes only)",
+    ),
+    (
+        "ttl_rtt_avg_seconds",
+        "gauge",
+        "Average RTT to this hop's primary responder",
+    ),
+    (
+        "ttl_rtt_min_seconds",
+        "gauge",
+        "Minimum RTT to this hop's primary responder",
+    ),
+    (
+        "ttl_rtt_max_seconds",
+        "gauge",
+        "Maximum RTT to this hop's primary responder",
+    ),
+    (
+        "ttl_rtt_stddev_seconds",
+        "gauge",
+        "RTT standard deviation for this hop's primary responder",
+    ),
+    (
+        "ttl_hop_responders",
+        "gauge",
+        "Distinct responder IPs seen at this hop (ECMP)",
+    ),
+    (
+        "ttl_hop_info",
+        "gauge",
+        "Primary responder identity for this hop (always 1)",
+    ),
+    (
+        "ttl_target_reachable",
+        "gauge",
+        "Whether the destination has responded (1) or not (0)",
+    ),
+    (
+        "ttl_path_hops",
+        "gauge",
+        "Hop count at which the destination responded",
+    ),
+    (
+        "ttl_target_probes_total",
+        "counter",
+        "Total completed probes across all hops for this target",
+    ),
+];
+
+/// Escape a label value per the Prometheus exposition format
+fn escape_label(s: &str) -> String {
+    sanitize_display(s)
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+/// Render all sessions as Prometheus exposition text
+pub fn render_metrics(sessions: &SessionMap) -> String {
+    // Collect sample lines per metric, then emit grouped under HELP/TYPE
+    // headers in METRICS order (the exposition format requires grouping).
+    let mut samples: std::collections::HashMap<&str, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut push = |metric: &'static str, labels: String, value: f64| {
+        samples
+            .entry(metric)
+            .or_default()
+            .push(format!("{}{{{}}} {}", metric, labels, value));
+    };
+
+    let sessions_read = sessions.read();
+    for (target_ip, state) in sessions_read.iter() {
+        let session = state.read();
+        let target = format!(
+            "target=\"{}\",host=\"{}\"",
+            target_ip,
+            escape_label(&session.target.original)
+        );
+
+        for hop in &session.hops {
+            if hop.sent == 0 {
+                continue;
+            }
+            let hop_labels = format!("{},ttl=\"{}\"", target, hop.ttl);
+            push("ttl_probes_sent_total", hop_labels.clone(), hop.sent as f64);
+            push(
+                "ttl_responses_total",
+                hop_labels.clone(),
+                hop.received as f64,
+            );
+            push(
+                "ttl_timeouts_total",
+                hop_labels.clone(),
+                hop.timeouts as f64,
+            );
+            push("ttl_loss_ratio", hop_labels.clone(), hop.loss_pct() / 100.0);
+            if let Some(stats) = hop.primary_stats() {
+                push(
+                    "ttl_rtt_avg_seconds",
+                    hop_labels.clone(),
+                    stats.avg_rtt().as_secs_f64(),
+                );
+                push(
+                    "ttl_rtt_min_seconds",
+                    hop_labels.clone(),
+                    stats.min_rtt.as_secs_f64(),
+                );
+                push(
+                    "ttl_rtt_max_seconds",
+                    hop_labels.clone(),
+                    stats.max_rtt.as_secs_f64(),
+                );
+                push(
+                    "ttl_rtt_stddev_seconds",
+                    hop_labels.clone(),
+                    stats.stddev().as_secs_f64(),
+                );
+                push(
+                    "ttl_hop_responders",
+                    hop_labels.clone(),
+                    hop.responders.len() as f64,
+                );
+                let hostname = stats.hostname.as_deref().unwrap_or("");
+                push(
+                    "ttl_hop_info",
+                    format!(
+                        "{},ip=\"{}\",hostname=\"{}\"",
+                        hop_labels,
+                        stats.ip,
+                        escape_label(hostname)
+                    ),
+                    1.0,
+                );
+            }
+        }
+
+        push(
+            "ttl_target_reachable",
+            target.clone(),
+            if session.complete { 1.0 } else { 0.0 },
+        );
+        if let Some(dest_ttl) = session.dest_ttl {
+            push("ttl_path_hops", target.clone(), dest_ttl as f64);
+        }
+        push(
+            "ttl_target_probes_total",
+            target.clone(),
+            session.total_sent as f64,
+        );
+    }
+    drop(sessions_read);
+
+    let mut out = String::new();
+    for (name, kind, help) in METRICS {
+        if let Some(lines) = samples.get(name) {
+            out.push_str(&format!(
+                "# HELP {} {}\n# TYPE {} {}\n",
+                name, help, name, kind
+            ));
+            for line in lines {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// Accept loop for the exporter; runs until cancellation
+pub async fn run_metrics_server(
+    listener: TcpListener,
+    sessions: SessionMap,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            accepted = listener.accept() => {
+                let Ok((stream, _)) = accepted else { continue };
+                let sessions = sessions.clone();
+                tokio::spawn(async move {
+                    let _ = handle_connection(stream, sessions).await;
+                });
+            }
+        }
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream, sessions: SessionMap) -> Result<()> {
+    // Read the request head; 1KB is plenty for "GET /metrics HTTP/1.1" + headers
+    let mut buf = [0u8; 1024];
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .context("request read timed out")??;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let mut parts = request.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("/");
+
+    let (status, content_type, body) = if method != "GET" {
+        (
+            "405 Method Not Allowed",
+            "text/plain; charset=utf-8",
+            "method not allowed\n".to_string(),
+        )
+    } else {
+        match path {
+            "/metrics" => (
+                "200 OK",
+                "text/plain; version=0.0.4; charset=utf-8",
+                render_metrics(&sessions),
+            ),
+            "/healthz" | "/health" => ("200 OK", "text/plain; charset=utf-8", "ok\n".to_string()),
+            _ => (
+                "404 Not Found",
+                "text/plain; charset=utf-8",
+                "not found\n".to_string(),
+            ),
+        }
+    };
+
+    let response = format!(
+        "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status,
+        content_type,
+        body.len(),
+        body
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.shutdown().await.ok();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::state::{Session, Target};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    fn make_session_map() -> SessionMap {
+        let target_ip = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        let target = Target::new("dns.example".to_string(), target_ip);
+        let mut session = Session::new(target, Config::default());
+        if let Some(hop) = session.hop_mut(1) {
+            hop.record_sent();
+            hop.record_response(
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                Duration::from_millis(5),
+            );
+            hop.record_sent();
+            hop.record_timeout();
+        }
+        session.complete = true;
+        session.dest_ttl = Some(1);
+        session.total_sent = 2;
+
+        let mut map = HashMap::new();
+        map.insert(target_ip, Arc::new(RwLock::new(session)));
+        Arc::new(RwLock::new(map))
+    }
+
+    #[test]
+    fn test_render_metrics_basic() {
+        let sessions = make_session_map();
+        let text = render_metrics(&sessions);
+        assert!(text.contains("# TYPE ttl_probes_sent_total counter"));
+        assert!(text.contains(
+            "ttl_probes_sent_total{target=\"8.8.8.8\",host=\"dns.example\",ttl=\"1\"} 2"
+        ));
+        assert!(
+            text.contains(
+                "ttl_responses_total{target=\"8.8.8.8\",host=\"dns.example\",ttl=\"1\"} 1"
+            )
+        );
+        assert!(
+            text.contains(
+                "ttl_timeouts_total{target=\"8.8.8.8\",host=\"dns.example\",ttl=\"1\"} 1"
+            )
+        );
+        assert!(
+            text.contains("ttl_loss_ratio{target=\"8.8.8.8\",host=\"dns.example\",ttl=\"1\"} 0.5")
+        );
+        assert!(text.contains(
+            "ttl_rtt_avg_seconds{target=\"8.8.8.8\",host=\"dns.example\",ttl=\"1\"} 0.005"
+        ));
+        assert!(text.contains("ip=\"10.0.0.1\""));
+        assert!(text.contains("ttl_target_reachable{target=\"8.8.8.8\",host=\"dns.example\"} 1"));
+        assert!(text.contains("ttl_path_hops{target=\"8.8.8.8\",host=\"dns.example\"} 1"));
+        assert!(
+            text.contains("ttl_target_probes_total{target=\"8.8.8.8\",host=\"dns.example\"} 2")
+        );
+    }
+
+    #[test]
+    fn test_render_metrics_skips_unprobed_hops() {
+        let sessions = make_session_map();
+        let text = render_metrics(&sessions);
+        // Only TTL 1 was probed; no ttl="2" series should exist
+        assert!(!text.contains("ttl=\"2\""));
+    }
+
+    #[test]
+    fn test_label_escaping() {
+        assert_eq!(escape_label("plain"), "plain");
+        assert_eq!(escape_label("with\"quote"), "with\\\"quote");
+        assert_eq!(escape_label("back\\slash"), "back\\\\slash");
+        // Control chars stripped by sanitize_display before escaping
+        assert_eq!(escape_label("evil\x1b[31m"), "evil[31m");
+    }
+
+    #[tokio::test]
+    async fn test_http_endpoints() {
+        let sessions = make_session_map();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let cancel = CancellationToken::new();
+        let server = tokio::spawn(run_metrics_server(listener, sessions, cancel.clone()));
+
+        let fetch = |path: &'static str| async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(format!("GET {} HTTP/1.1\r\nHost: x\r\n\r\n", path).as_bytes())
+                .await
+                .unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).await.unwrap();
+            response
+        };
+
+        let metrics = fetch("/metrics").await;
+        assert!(metrics.starts_with("HTTP/1.1 200 OK"));
+        assert!(metrics.contains("ttl_probes_sent_total"));
+
+        let health = fetch("/healthz").await;
+        assert!(health.starts_with("HTTP/1.1 200 OK"));
+        assert!(health.contains("ok"));
+
+        let missing = fetch("/nope").await;
+        assert!(missing.starts_with("HTTP/1.1 404"));
+
+        cancel.cancel();
+        server.await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **Docker & Daemon Mode** roadmap section (all items except Docker Hub publishing, which needs registry credentials).

### Daemon mode (`--daemon`)

- Headless probing with no per-hop stdout — for container/monitoring deployments
- Composes with `--prometheus` and/or `--stream-json`; warns when started with neither (no output sink)
- Conflicts with batch output flags and replay/diff

### Prometheus exporter (`--prometheus <ADDR>`)

- `:9090` shorthand binds all interfaces; full `host:port` also accepted; invalid addresses rejected at arg validation
- `GET /metrics` — OpenMetrics exposition: per-hop sent/response/timeout counters, RTT avg/min/max/stddev gauges, loss ratio, ECMP responder count, `ttl_hop_info` identity series; per-target reachability, path hops, total probes. Labels: `target` (resolved IP), `host` (name as given), `ttl`
- `GET /healthz` — 200 for container orchestration
- Hand-rolled HTTP/1.1 over the existing tokio runtime — **no new dependencies**; label values sanitized and escaped
- Binds before workers spawn so port conflicts fail fast with a clear error

### SIGTERM handling

`docker stop` now triggers the same graceful shutdown as Ctrl-C (repeat signal forces exit). Verified: container exits 0, not 143.

### Dockerfile

Multi-stage `rust:1.88-alpine` (MSRV) → `alpine:3.21` with CA certificates for enrichment lookups. Docker grants `CAP_NET_RAW` by default; docs cover `--cap-add NET_RAW` / Kubernetes `securityContext` for stricter runtimes.

## Testing

- 15 new tests (255 total passing): metrics rendering (counters/gauges/info series, unprobed-hop skipping, label escaping), async HTTP endpoint test (200/404/healthz), CLI parsing (`:9090` shorthand, invalid addr rejection, conflict matrix, daemon+stream-json+prometheus composition)
- `cargo fmt --check` / `clippy --all-targets -- -D warnings` clean
- Live-verified in Docker: image builds (~2min), `--daemon --prometheus :9090 1.1.1.1` serves real probe metrics, `curl /healthz` 200, `docker stop` → graceful SIGTERM shutdown, exit code 0