### PR TITLE
Add interactive target selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Interactive target selection**: run `ttl` with no arguments to open an empty session, then press `o` to add targets — also works mid-session in any live TUI run. Hostnames resolve in the background with a loading state; probe engines (and receivers, for a new IP family) spawn at runtime. Entering an already-traced host switches to it.
 - **Daemon mode** (`--daemon`): headless probing with no per-hop stdout, for container/monitoring deployments. Combine with `--prometheus` and/or `--stream-json` to consume the data.
 - **Prometheus exporter** (`--prometheus <ADDR>`, e.g. `:9090`): OpenMetrics endpoint with per-hop sent/response/timeout counters, RTT avg/min/max/stddev gauges, loss ratio, ECMP responder count, hop identity info series, and per-target reachability/path-length metrics. Includes `GET /healthz` for container orchestration. Hand-rolled over the existing tokio runtime — no new dependencies.
 - **SIGTERM handling**: `docker stop` now triggers the same graceful shutdown as Ctrl-C (unix).

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ When a hostname resolves to multiple IPs (round-robin DNS, CDN load balancing), 
 | `e` | Export JSON |
 | `?` | Help |
 | `u` | Dismiss update banner |
+| `o` | Add target |
 | `Tab` | Next target |
 | `l` | Target list |
 | `Enter` | Expand hop |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,12 +134,12 @@
 
 **Why this matters:** Power users want to add and manage targets without restarting. This makes ttl a persistent network investigation tool.
 
-- [ ] `ttl` with no args enters interactive mode
-- [ ] Press `o` to open target input modal
-- [ ] Text input with hostname/IP validation
-- [ ] DNS resolution with loading state
-- [ ] Add additional targets mid-session
-- [ ] Empty state UI: "Press 'o' to add target"
+- [x] `ttl` with no args enters interactive mode
+- [x] Press `o` to open target input modal
+- [x] Text input with hostname/IP validation
+- [x] DNS resolution with loading state
+- [x] Add additional targets mid-session
+- [x] Empty state UI: "Press 'o' to add target"
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -86,6 +86,22 @@ ttl automatically detects NAT devices that rewrite source ports:
 - Displays "NAT" indicator in hop details when mismatch detected
 - Useful for diagnosing carrier-grade NAT (CGNAT) or enterprise NAT
 
+## Interactive Target Selection
+
+```bash
+ttl              # Start with an empty session
+```
+
+Run `ttl` with no arguments to open an empty interactive session, then press
+`o` to add targets. The input modal resolves hostnames in the background
+(showing a "Resolving..." state) and starts probing immediately on success —
+no restart needed. Targets can also be added mid-session in any live TUI run;
+entering a host that's already being traced switches to it.
+
+Probe infrastructure scales at runtime: each added target gets its own probe
+engine, and a packet receiver is started for an IP family the first time a
+target of that family is added.
+
 ## Multi-IP Resolution
 
 ```bash
@@ -386,6 +402,7 @@ High jitter indicates path instability from congestion, route changes, or load b
 | `s` | Open settings modal |
 | `e` | Export current session to JSON |
 | `?` / `h` | Show help dialog |
+| `o` | Add a target (works mid-session and from the empty state) |
 | `Tab` / `n` | Switch to next target |
 | `Shift-Tab` / `N` | Switch to previous target |
 | `l` | Open target list (multi-target mode) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ EXAMPLES:
     Basic tracing:
         ttl 8.8.8.8
         ttl google.com cloudflare.com    # Multiple targets
+        ttl                              # Empty session; press 'o' to add targets
 
     Protocol selection:
         ttl -p udp google.com            # UDP probes
@@ -47,8 +48,8 @@ DETECTION INDICATORS:
 For detailed documentation: https://github.com/lance0/ttl/blob/master/docs/FEATURES.md
 ")]
 pub struct Args {
-    /// Target hosts to trace (IP address or hostname)
-    #[arg(required_unless_present_any = ["completions", "replay", "diff"])]
+    /// Target hosts to trace (IP address or hostname).
+    /// With no targets, opens an interactive empty session (press 'o' to add).
     pub targets: Vec<String>,
 
     /// Number of probe rounds (0 = infinite). Each round sends probes to all TTLs.
@@ -245,6 +246,12 @@ impl Args {
 
     /// Validate arguments
     pub fn validate(&self) -> Result<(), String> {
+        // Interactive TUI mode supports starting empty (add targets with 'o');
+        // every other mode needs at least one target up front
+        if self.targets.is_empty() && (self.is_batch_mode() || self.is_headless()) {
+            return Err("No targets specified (required for non-interactive modes)".into());
+        }
+
         if self.is_batch_mode() && self.count == 0 {
             return Err("Batch output modes (--json, --csv, --report) require -c to be set".into());
         }
@@ -478,6 +485,46 @@ mod tests {
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--json", "8.8.8.8"]).is_err());
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--csv", "8.8.8.8"]).is_err());
         assert!(Args::try_parse_from(["ttl", "--stream-json", "--report", "8.8.8.8"]).is_err());
+    }
+
+    #[test]
+    fn test_empty_targets_interactive_ok() {
+        let args = make_args(|a| a.targets = vec![]);
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_empty_targets_rejected_for_non_interactive_modes() {
+        let no_tui = make_args(|a| {
+            a.targets = vec![];
+            a.no_tui = true;
+        });
+        assert!(no_tui.validate().unwrap_err().contains("No targets"));
+
+        let batch = make_args(|a| {
+            a.targets = vec![];
+            a.json = true;
+            a.count = 5;
+        });
+        assert!(batch.validate().is_err());
+
+        let daemon = make_args(|a| {
+            a.targets = vec![];
+            a.daemon = true;
+        });
+        assert!(daemon.validate().is_err());
+
+        let stream = make_args(|a| {
+            a.targets = vec![];
+            a.stream_json = true;
+        });
+        assert!(stream.validate().is_err());
+
+        let prom = make_args(|a| {
+            a.targets = vec![];
+            a.prometheus = Some(":9090".to_string());
+        });
+        assert!(prom.validate().is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ use trace::engine::ProbeEngine;
 use trace::pending::{PendingMap, new_pending_map};
 use trace::receiver::{ReceiverConfig, SessionMap, spawn_receiver};
 use tui::app::{ReplayState, ResolveInfo, run_tui};
+use tui::views::target_input::{AddTargetRequest, AddedTarget};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -204,7 +205,9 @@ async fn main() -> Result<()> {
         None
     };
 
-    if targets.is_empty() {
+    // Empty args.targets means interactive empty mode (add targets with 'o');
+    // headless/batch modes without targets are rejected by args.validate().
+    if targets.is_empty() && !args.targets.is_empty() {
         anyhow::bail!("No valid targets specified");
     }
 
@@ -259,8 +262,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Validate source IP matches target IP family
-    if let Some(source_ip) = config.source_ip {
+    // Validate source IP matches target IP family (with no initial targets,
+    // the family check happens when each target is added)
+    if let Some(source_ip) = config.source_ip
+        && !targets.is_empty()
+    {
         if mixed {
             eprintln!(
                 "Error: --source-ip cannot be used with mixed IPv4/IPv6 targets. \
@@ -517,6 +523,7 @@ async fn run_replay_mode(args: &Args, replay_path: &str) -> Result<()> {
             None,
             None,
             replay_state,
+            None, // add_target_tx (replay mode has no live probing)
         )
         .await?;
 
@@ -897,6 +904,32 @@ async fn run_interactive_mode(
     // Spawn rate limit detection worker (always enabled, lightweight analysis)
     let ratelimit_handle = tokio::spawn(run_ratelimit_worker(sessions.clone(), cancel.clone()));
 
+    // Spawn the target manager: resolves and starts probing targets added
+    // at runtime via the TUI's 'o' modal
+    let (add_target_tx, add_target_rx) = tokio::sync::mpsc::unbounded_channel();
+    let manager_handle = {
+        let has_v4_receiver = targets.iter().any(|t| t.is_ipv4());
+        let has_v6_receiver = targets.iter().any(|t| t.is_ipv6());
+        let effective_flows_v4 = has_v4_receiver
+            .then(|| session_effective_flows_for_family(&sessions, &targets, false, config.flows));
+        let effective_flows_v6 = has_v6_receiver
+            .then(|| session_effective_flows_for_family(&sessions, &targets, true, config.flows));
+        tokio::spawn(run_target_manager(TargetManagerCtx {
+            rx: add_target_rx,
+            sessions: sessions.clone(),
+            pending: pending.clone(),
+            cancel: cancel.clone(),
+            interface: interface.clone(),
+            config: config.clone(),
+            force_ipv4: args.ipv4,
+            force_ipv6: args.ipv6,
+            has_v4_receiver,
+            has_v6_receiver,
+            effective_flows_v4,
+            effective_flows_v6,
+        }))
+    };
+
     // Run TUI (with target list for cycling)
     // Pass update_rx directly — TUI polls it non-blocking each tick
     let final_prefs = run_tui(
@@ -908,6 +941,7 @@ async fn run_interactive_mode(
         ix_lookup.clone(),
         Some(update_rx),
         None, // replay_state (live mode)
+        Some(add_target_tx),
     )
     .await?;
 
@@ -926,6 +960,9 @@ async fn run_interactive_mode(
     shutdown_log("interactive joining receiver threads");
     join_receivers(receiver_handles)?;
     shutdown_log("interactive receiver threads joined");
+    shutdown_log("interactive waiting for target manager");
+    manager_handle.await??;
+    shutdown_log("interactive target manager joined");
     if let Some(handle) = dns_handle {
         shutdown_log("interactive waiting for dns worker");
         handle.await?;
@@ -949,6 +986,186 @@ async fn run_interactive_mode(
     shutdown_log("interactive waiting for ratelimit worker");
     ratelimit_handle.await?;
     shutdown_log("interactive ratelimit worker joined");
+
+    Ok(())
+}
+
+/// Everything the target manager needs to start probing a new target
+struct TargetManagerCtx {
+    rx: tokio::sync::mpsc::UnboundedReceiver<AddTargetRequest>,
+    sessions: SessionMap,
+    pending: PendingMap,
+    cancel: CancellationToken,
+    interface: Option<InterfaceInfo>,
+    config: Config,
+    force_ipv4: bool,
+    force_ipv6: bool,
+    has_v4_receiver: bool,
+    has_v6_receiver: bool,
+    effective_flows_v4: Option<u8>,
+    effective_flows_v6: Option<u8>,
+}
+
+/// Handle add-target requests from the TUI: resolve the host, create the
+/// session, spawn its probe engine, and spawn a receiver if the IP family
+/// is new. Owns the handles it spawns and joins them after cancellation.
+async fn run_target_manager(mut ctx: TargetManagerCtx) -> Result<()> {
+    let mut engine_handles = Vec::new();
+    let mut receiver_handles = Vec::new();
+
+    loop {
+        let request = tokio::select! {
+            _ = ctx.cancel.cancelled() => break,
+            req = ctx.rx.recv() => match req {
+                Some(r) => r,
+                None => break,
+            },
+        };
+
+        let host = request.host.clone();
+        let (force_v4, force_v6) = (ctx.force_ipv4, ctx.force_ipv6);
+        let resolved =
+            tokio::task::spawn_blocking(move || resolve_target(&host, force_v4, force_v6)).await;
+        let ip = match resolved {
+            Ok(Ok(ip)) => ip,
+            Ok(Err(e)) => {
+                let _ = request.reply.send(Err(format!("{:#}", e)));
+                continue;
+            }
+            Err(e) => {
+                let _ = request
+                    .reply
+                    .send(Err(format!("Resolver task failed: {}", e)));
+                continue;
+            }
+        };
+
+        if ctx.sessions.read().contains_key(&ip) {
+            let _ = request.reply.send(Ok(AddedTarget {
+                ip,
+                name: request.host,
+                existed: true,
+            }));
+            continue;
+        }
+
+        let ipv6 = ip.is_ipv6();
+
+        // Family constraints validated at startup for initial targets
+        if let Some(source_ip) = ctx.config.source_ip
+            && source_ip.is_ipv6() != ipv6
+        {
+            let _ = request.reply.send(Err(format!(
+                "--source-ip {} does not match target family",
+                source_ip
+            )));
+            continue;
+        }
+        if let Some(ref info) = ctx.interface {
+            if ipv6 && info.ipv6.is_none() {
+                let _ = request.reply.send(Err(format!(
+                    "Interface '{}' has no IPv6 address",
+                    info.name
+                )));
+                continue;
+            }
+            if !ipv6 && info.ipv4.is_none() {
+                let _ = request.reply.send(Err(format!(
+                    "Interface '{}' has no IPv4 address",
+                    info.name
+                )));
+                continue;
+            }
+        }
+
+        // Per-target config with effective flow capability for its family
+        let mut flows_v4 = ctx.effective_flows_v4;
+        let mut flows_v6 = ctx.effective_flows_v6;
+        let target_config = config_for_target_effective_flows(
+            &ctx.config,
+            ip,
+            ctx.interface.as_ref(),
+            &mut flows_v4,
+            &mut flows_v6,
+        );
+        ctx.effective_flows_v4 = flows_v4;
+        ctx.effective_flows_v6 = flows_v6;
+
+        let target = Target::new(request.host.clone(), ip);
+        let mut session = Session::new(target, target_config);
+        session.source_ip = ctx.config.source_ip.or_else(|| {
+            let addr = get_local_addr_with_interface(ip, ctx.interface.as_ref());
+            if addr.is_unspecified() {
+                None
+            } else {
+                Some(addr)
+            }
+        });
+        session.gateway = if let Some(ref info) = ctx.interface {
+            if ipv6 {
+                info.gateway_ipv6.map(IpAddr::V6)
+            } else {
+                info.gateway_ipv4.map(IpAddr::V4)
+            }
+        } else {
+            detect_default_gateway(ipv6)
+        };
+
+        let state = Arc::new(RwLock::new(session));
+        ctx.sessions.write().insert(ip, state.clone());
+
+        // Spawn a receiver if this IP family doesn't have one yet
+        let family_has_receiver = if ipv6 {
+            &mut ctx.has_v6_receiver
+        } else {
+            &mut ctx.has_v4_receiver
+        };
+        if !*family_has_receiver {
+            let num_flows = if ipv6 { flows_v6 } else { flows_v4 }.unwrap_or(1);
+            let receiver_config = ReceiverConfig {
+                timeout: ctx.config.timeout,
+                ipv6,
+                src_port_base: ctx.config.src_port_base,
+                num_flows,
+                interface: ctx.interface.clone(),
+                recv_any: ctx.config.recv_any,
+            };
+            receiver_handles.push(spawn_receiver(
+                ctx.sessions.clone(),
+                ctx.pending.clone(),
+                ctx.cancel.clone(),
+                receiver_config,
+            ));
+            *family_has_receiver = true;
+        }
+
+        // Spawn the probe engine
+        let engine_config = state.read().config.clone();
+        let engine = ProbeEngine::new(
+            engine_config,
+            ip,
+            state.clone(),
+            ctx.pending.clone(),
+            ctx.cancel.clone(),
+            ctx.interface.clone(),
+        );
+        engine_handles.push(tokio::spawn(async move { engine.run().await }));
+
+        let _ = request.reply.send(Ok(AddedTarget {
+            ip,
+            name: request.host,
+            existed: false,
+        }));
+    }
+
+    // Join everything this task spawned (cancellation already requested)
+    shutdown_log("target manager waiting for its probe engines");
+    for handle in engine_handles {
+        handle.await??;
+    }
+    shutdown_log("target manager joining its receiver threads");
+    tokio::task::spawn_blocking(move || join_receivers(receiver_handles)).await??;
+    shutdown_log("target manager receivers joined");
 
     Ok(())
 }

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -73,8 +73,6 @@ pub struct Receiver {
     cancel: CancellationToken,
     config: ReceiverConfig,
     consecutive_errors: u32,
-    /// List of target IPs for probe lookup (cached from sessions keys)
-    targets: Vec<IpAddr>,
 }
 
 impl Receiver {
@@ -84,15 +82,12 @@ impl Receiver {
         cancel: CancellationToken,
         config: ReceiverConfig,
     ) -> Self {
-        // Cache target list for probe lookup
-        let targets: Vec<IpAddr> = sessions.read().keys().cloned().collect();
         Self {
             sessions,
             pending,
             cancel,
             config,
             consecutive_errors: 0,
-            targets,
         }
     }
 
@@ -201,6 +196,12 @@ impl Receiver {
                             // Find matching pending probe (key includes flow_id, target, is_pmtud)
                             let mut found_probe = None;
                             {
+                                // Read live target list before taking the pending lock
+                                // (targets can be added mid-session in interactive mode;
+                                // sessions lock is never acquired while pending is held)
+                                let fallback_targets: Vec<IpAddr> =
+                                    self.sessions.read().keys().copied().collect();
+
                                 let mut pending = self.pending.write();
 
                                 // If we have original_dest from ICMP error, use direct lookup
@@ -215,7 +216,7 @@ impl Receiver {
 
                                 // Fallback: iterate targets (for Echo Reply which has no quoted dest)
                                 if found_probe.is_none() {
-                                    for target in &self.targets {
+                                    for target in &fallback_targets {
                                         if let Some(probe) = Self::remove_pending_by_flow_hint(
                                             &mut pending,
                                             parsed.probe_id,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -26,8 +26,8 @@ use crate::state::{ProbeEvent, Session};
 use crate::trace::receiver::SessionMap;
 use crate::tui::theme::Theme;
 use crate::tui::views::{
-    HelpView, HopDetailView, MainView, SettingsState, SettingsView, TargetInfo, TargetListView,
-    extract_target_infos,
+    AddTargetRequest, HelpView, HopDetailView, MainView, SettingsState, SettingsView, TargetInfo,
+    TargetInputState, TargetInputView, TargetListView, extract_target_infos,
 };
 
 /// State for animated replay playback
@@ -108,6 +108,10 @@ pub struct UiState {
     pub target_list_cache: Option<Vec<TargetInfo>>,
     /// Tick counter for target list cache refresh
     pub target_list_tick: u32,
+    /// Show target input modal
+    pub show_target_input: bool,
+    /// Target input modal state
+    pub target_input: TargetInputState,
 }
 
 impl UiState {
@@ -135,6 +139,7 @@ pub async fn run_tui(
     ix_lookup: Option<Arc<IxLookup>>,
     update_rx: Option<std::sync::mpsc::Receiver<Option<String>>>,
     replay_state: Option<ReplayState>,
+    add_target_tx: Option<tokio::sync::mpsc::UnboundedSender<AddTargetRequest>>,
 ) -> Result<Prefs> {
     // Setup terminal
     enable_raw_mode()?;
@@ -196,6 +201,7 @@ pub async fn run_tui(
         cancel.clone(),
         tick_rate,
         ix_lookup.clone(),
+        add_target_tx,
     )
     .await?;
 
@@ -469,21 +475,22 @@ fn adjust_replay_speed(ui_state: &mut UiState, delta: f32) {
     ui_state.set_status(format!("Speed: {:.1}x", new_speed));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_app<B>(
     terminal: &mut Terminal<B>,
     sessions: SessionMap,
-    targets: Vec<IpAddr>,
+    mut targets: Vec<IpAddr>,
     ui_state: &mut UiState,
     cancel: CancellationToken,
     tick_rate: Duration,
     ix_lookup: Option<Arc<IxLookup>>,
+    add_target_tx: Option<tokio::sync::mpsc::UnboundedSender<AddTargetRequest>>,
 ) -> Result<()>
 where
     B: ratatui::backend::Backend,
     B::Error: Send + Sync + 'static,
 {
     let theme_names = Theme::list();
-    let num_targets = targets.len();
     let ix_enabled = ix_lookup.is_some();
 
     loop {
@@ -492,8 +499,14 @@ where
             break;
         }
 
+        // Targets can grow at runtime via the add-target modal
+        let num_targets = targets.len();
+
         // Clear old status messages
         ui_state.clear_old_status();
+
+        // Poll for a pending add-target result (non-blocking)
+        poll_add_target_result(ui_state, &mut targets);
 
         // Poll for update check result (non-blocking)
         // Drop receiver once we get any result (Some or None) or sender disconnects
@@ -519,39 +532,46 @@ where
             let adjusted_elapsed = replay_current_ms(replay);
 
             // Capture target before acquiring locks to prevent race condition
-            let target_ip = targets[ui_state.selected_target];
-
-            // Find all events up to current adjusted time
-            let start = replay.current_index;
-            let mut end = start;
-            while end < replay.events.len() && replay.events[end].offset_ms <= adjusted_elapsed {
-                end += 1;
-            }
-
-            // Apply all events in a single lock acquisition (no per-event lock churn)
-            if end > start {
-                let sessions_read = sessions.read();
-                if let Some(session_lock) = sessions_read.get(&target_ip) {
-                    let mut session = session_lock.write();
-                    for event in &replay.events[start..end] {
-                        session.apply_replay_event(event);
-                    }
+            // (replay mode always has exactly one target)
+            if let Some(target_ip) = targets.get(ui_state.selected_target).copied() {
+                // Find all events up to current adjusted time
+                let start = replay.current_index;
+                let mut end = start;
+                while end < replay.events.len() && replay.events[end].offset_ms <= adjusted_elapsed
+                {
+                    end += 1;
                 }
-                replay.current_index = end;
-            }
 
-            // Check if replay is complete
-            if replay.current_index >= replay.events.len() {
-                replay.finished = true;
-                ui_state.set_status("Replay complete");
+                // Apply all events in a single lock acquisition (no per-event lock churn)
+                if end > start {
+                    let sessions_read = sessions.read();
+                    if let Some(session_lock) = sessions_read.get(&target_ip) {
+                        let mut session = session_lock.write();
+                        for event in &replay.events[start..end] {
+                            session.apply_replay_event(event);
+                        }
+                    }
+                    replay.current_index = end;
+                }
+
+                // Check if replay is complete
+                if replay.current_index >= replay.events.len() {
+                    replay.finished = true;
+                    ui_state.set_status("Replay complete");
+                }
             }
         }
 
         // Get current theme
         let theme = Theme::by_name(theme_names[ui_state.theme_index]);
 
-        // Get current target's session
-        let current_target = targets[ui_state.selected_target];
+        // Get current target's session. With no targets yet (interactive empty
+        // mode) the unspecified sentinel never matches a session, so all
+        // session-dependent key handlers below no-op gracefully.
+        let current_target = targets
+            .get(ui_state.selected_target)
+            .copied()
+            .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
 
         // Get cache status for settings modal
         let cache_status = ix_lookup.as_ref().map(|ix| ix.get_cache_status());
@@ -590,6 +610,11 @@ where
                     ix_enabled,
                 );
             })?;
+        } else {
+            // No targets yet (interactive empty mode)
+            terminal.draw(|f| {
+                draw_empty_state(f, ui_state, &theme, cache_status.clone(), ix_enabled);
+            })?;
         }
 
         // Handle input with timeout
@@ -603,6 +628,11 @@ where
             // Handle overlays first
             if ui_state.show_help {
                 ui_state.show_help = false;
+                continue;
+            }
+
+            if ui_state.show_target_input {
+                handle_target_input_key(key.code, key.modifiers, ui_state, &add_target_tx);
                 continue;
             }
 
@@ -905,6 +935,13 @@ where
                     );
                     ui_state.show_settings = true;
                 }
+                // Open target input modal (live mode only)
+                KeyCode::Char('o')
+                    if ui_state.replay_state.is_none() && add_target_tx.is_some() =>
+                {
+                    ui_state.target_input = TargetInputState::default();
+                    ui_state.show_target_input = true;
+                }
                 // Open target list overlay (only in multi-target mode)
                 KeyCode::Char('l') if num_targets > 1 => {
                     ui_state.target_list_index = ui_state.selected_target;
@@ -1019,6 +1056,154 @@ where
     }
 
     Ok(())
+}
+
+/// Poll the pending add-target reply; on success the new target joins the
+/// rotation and becomes selected.
+fn poll_add_target_result(ui_state: &mut UiState, targets: &mut Vec<IpAddr>) {
+    let Some(rx) = ui_state.target_input.pending.as_mut() else {
+        return;
+    };
+    match rx.try_recv() {
+        Ok(Ok(added)) => {
+            ui_state.target_input = TargetInputState::default();
+            ui_state.show_target_input = false;
+            if !targets.contains(&added.ip) {
+                targets.push(added.ip);
+            }
+            if let Some(idx) = targets.iter().position(|t| *t == added.ip) {
+                ui_state.selected_target = idx;
+                ui_state.selected = None;
+            }
+            if added.existed {
+                ui_state.set_status(format!("Already tracing {} ({})", added.name, added.ip));
+            } else {
+                ui_state.set_status(format!("Added target {} ({})", added.name, added.ip));
+            }
+        }
+        Ok(Err(msg)) => {
+            ui_state.target_input.pending = None;
+            ui_state.target_input.resolving = false;
+            ui_state.target_input.error = Some(msg);
+        }
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {}
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            ui_state.target_input.pending = None;
+            ui_state.target_input.resolving = false;
+            ui_state.target_input.error = Some("Target manager unavailable".to_string());
+        }
+    }
+}
+
+/// Key handling for the target input modal
+fn handle_target_input_key(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    ui_state: &mut UiState,
+    add_target_tx: &Option<tokio::sync::mpsc::UnboundedSender<AddTargetRequest>>,
+) {
+    match code {
+        KeyCode::Esc => {
+            ui_state.target_input = TargetInputState::default();
+            ui_state.show_target_input = false;
+        }
+        KeyCode::Enter => {
+            let host = ui_state.target_input.input.trim().to_string();
+            if host.is_empty() || ui_state.target_input.resolving {
+                return;
+            }
+            let Some(tx) = add_target_tx else { return };
+            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+            if tx
+                .send(AddTargetRequest {
+                    host,
+                    reply: reply_tx,
+                })
+                .is_ok()
+            {
+                ui_state.target_input.pending = Some(reply_rx);
+                ui_state.target_input.resolving = true;
+                ui_state.target_input.error = None;
+            } else {
+                ui_state.target_input.error = Some("Target manager unavailable".to_string());
+            }
+        }
+        KeyCode::Backspace => ui_state.target_input.handle_backspace(),
+        KeyCode::Delete => ui_state.target_input.handle_delete(),
+        KeyCode::Left => ui_state.target_input.move_cursor_left(),
+        KeyCode::Right => ui_state.target_input.move_cursor_right(),
+        KeyCode::Char(c) if !modifiers.contains(KeyModifiers::CONTROL) => {
+            ui_state.target_input.handle_char(c);
+        }
+        _ => {}
+    }
+}
+
+/// Draw the empty state shown when no targets are being traced yet
+fn draw_empty_state(
+    f: &mut ratatui::Frame,
+    ui_state: &UiState,
+    theme: &Theme,
+    cache_status: Option<crate::lookup::ix::CacheStatus>,
+    ix_enabled: bool,
+) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(area);
+
+    let lines = vec![
+        ratatui::text::Line::default(),
+        ratatui::text::Line::styled(
+            format!("ttl v{}", env!("CARGO_PKG_VERSION")),
+            Style::default().fg(theme.header),
+        ),
+        ratatui::text::Line::default(),
+        ratatui::text::Line::styled("No targets yet", Style::default().fg(theme.text_dim)),
+        ratatui::text::Line::default(),
+        ratatui::text::Line::styled("Press 'o' to add a target", Style::default().fg(theme.text)),
+    ];
+    let empty = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+    f.render_widget(empty, chunks[0]);
+
+    let (status_text, status_style): (Cow<'_, str>, Style) =
+        if let Some((ref msg, _)) = ui_state.status_message {
+            (
+                Cow::Borrowed(msg.as_str()),
+                Style::default().fg(theme.text_dim),
+            )
+        } else {
+            (
+                Cow::Borrowed("q quit | o add target | t theme | s settings | ? help"),
+                Style::default().fg(theme.text_dim),
+            )
+        };
+    f.render_widget(
+        Paragraph::new(status_text.as_ref()).style(status_style),
+        chunks[1],
+    );
+
+    // Overlays available in empty mode
+    if ui_state.show_help {
+        f.render_widget(HelpView::new(theme).with_replay(false), area);
+    }
+    if ui_state.show_settings {
+        let theme_names = Theme::list();
+        f.render_widget(
+            SettingsView::new(
+                theme,
+                &ui_state.settings,
+                theme_names,
+                cache_status,
+                ix_enabled,
+            ),
+            area,
+        );
+    }
+    if ui_state.show_target_input {
+        f.render_widget(TargetInputView::new(theme, &ui_state.target_input), area);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1154,14 +1339,14 @@ fn draw_ui(
     } else if num_targets > 1 {
         (
             Cow::Borrowed(
-                "q quit | Tab next | l list | p pause | r reset | t theme | w display | s settings | e export | ? help",
+                "q quit | Tab next | l list | o add | p pause | r reset | t theme | w display | s settings | e export | ? help",
             ),
             Style::default().fg(theme.text_dim),
         )
     } else {
         (
             Cow::Borrowed(
-                "q quit | p pause | r reset | t theme | w display | s settings | e export | ? help",
+                "q quit | o add | p pause | r reset | t theme | w display | s settings | e export | ? help",
             ),
             Style::default().fg(theme.text_dim),
         )
@@ -1208,6 +1393,10 @@ fn draw_ui(
             TargetListView::new(theme, infos, ui_state.target_list_index),
             area,
         );
+    }
+
+    if ui_state.show_target_input {
+        f.render_widget(TargetInputView::new(theme, &ui_state.target_input), area);
     }
 }
 

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -88,6 +88,10 @@ impl Widget for HelpView<'_> {
             ]),
             Line::from(""),
             Line::from(vec![
+                Span::styled("  o       ", Style::default().fg(self.theme.shortcut)),
+                Span::raw("Add target"),
+            ]),
+            Line::from(vec![
                 Span::styled("  Tab/n   ", Style::default().fg(self.theme.shortcut)),
                 Span::raw("Next target (multi-target)"),
             ]),

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -2,10 +2,12 @@ pub mod help;
 pub mod hop;
 pub mod main;
 pub mod settings;
+pub mod target_input;
 pub mod targets;
 
 pub use help::*;
 pub use hop::*;
 pub use main::*;
 pub use settings::*;
+pub use target_input::*;
 pub use targets::*;

--- a/src/tui/views/target_input.rs
+++ b/src/tui/views/target_input.rs
@@ -1,0 +1,208 @@
+//! Target input modal: add a target mid-session (or from the empty state).
+//!
+//! The TUI sends an [`AddTargetRequest`] to the target-manager task in main,
+//! which resolves the hostname, creates the session, and spawns the probe
+//! engine (and a receiver if the IP family is new). The result comes back on
+//! a oneshot channel polled each tick.
+
+use std::net::IpAddr;
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
+
+use crate::tui::theme::Theme;
+
+/// A successfully added (or already-tracked) target
+#[derive(Debug, Clone)]
+pub struct AddedTarget {
+    pub ip: IpAddr,
+    pub name: String,
+    /// True if the target was already being traced
+    pub existed: bool,
+}
+
+/// Request from the TUI to the target-manager task
+pub struct AddTargetRequest {
+    /// Hostname or IP as typed by the user
+    pub host: String,
+    /// Reply channel: Ok on success, Err with a user-facing message
+    pub reply: tokio::sync::oneshot::Sender<Result<AddedTarget, String>>,
+}
+
+/// State for the target input modal
+#[derive(Default)]
+pub struct TargetInputState {
+    /// Current input text (ASCII only; cursor is a byte offset)
+    pub input: String,
+    /// Cursor position within input
+    pub cursor: usize,
+    /// Error message from the last failed attempt
+    pub error: Option<String>,
+    /// Whether a resolution is in flight
+    pub resolving: bool,
+    /// Pending reply from the target manager
+    pub pending: Option<tokio::sync::oneshot::Receiver<Result<AddedTarget, String>>>,
+}
+
+impl TargetInputState {
+    /// Insert a character at the cursor (ASCII only, keeps cursor math valid)
+    pub fn handle_char(&mut self, c: char) {
+        if c.is_ascii() && !c.is_ascii_control() {
+            self.input.insert(self.cursor, c);
+            self.cursor += 1;
+        }
+    }
+
+    /// Delete the character before the cursor
+    pub fn handle_backspace(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            self.input.remove(self.cursor);
+        }
+    }
+
+    /// Delete the character at the cursor
+    pub fn handle_delete(&mut self) {
+        if self.cursor < self.input.len() {
+            self.input.remove(self.cursor);
+        }
+    }
+
+    pub fn move_cursor_left(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_cursor_right(&mut self) {
+        if self.cursor < self.input.len() {
+            self.cursor += 1;
+        }
+    }
+}
+
+/// Centered modal for entering a new target
+pub struct TargetInputView<'a> {
+    theme: &'a Theme,
+    state: &'a TargetInputState,
+}
+
+impl<'a> TargetInputView<'a> {
+    pub fn new(theme: &'a Theme, state: &'a TargetInputState) -> Self {
+        Self { theme, state }
+    }
+}
+
+impl Widget for TargetInputView<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let width = 50.min(area.width.saturating_sub(4));
+        let height = 7;
+        if width < 20 || area.height < height {
+            return;
+        }
+        let modal = Rect {
+            x: area.x + (area.width - width) / 2,
+            y: area.y + (area.height.saturating_sub(height)) / 2,
+            width,
+            height,
+        };
+
+        Clear.render(modal, buf);
+
+        let block = Block::default()
+            .title(" Add Target ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(self.theme.border_focused));
+        let inner = block.inner(modal);
+        block.render(modal, buf);
+
+        // Input line with cursor
+        let (before, after) = self.state.input.split_at(self.state.cursor);
+        let input_line = Line::from(vec![
+            Span::styled("> ", Style::default().fg(self.theme.text_dim)),
+            Span::styled(before, Style::default().fg(self.theme.text)),
+            Span::styled(
+                "\u{2502}",
+                Style::default()
+                    .fg(self.theme.shortcut)
+                    .add_modifier(Modifier::SLOW_BLINK),
+            ),
+            Span::styled(after, Style::default().fg(self.theme.text)),
+        ]);
+
+        // Status line: error > resolving > hint
+        let status_line = if let Some(ref err) = self.state.error {
+            Line::from(Span::styled(
+                err.as_str(),
+                Style::default().fg(self.theme.error),
+            ))
+        } else if self.state.resolving {
+            Line::from(Span::styled(
+                "Resolving...",
+                Style::default().fg(self.theme.warning),
+            ))
+        } else {
+            Line::from(Span::styled(
+                "Hostname or IP address",
+                Style::default().fg(self.theme.text_dim),
+            ))
+        };
+
+        let hint_line = Line::from(Span::styled(
+            "Enter add \u{00b7} Esc cancel",
+            Style::default().fg(self.theme.text_dim),
+        ));
+
+        let text = vec![
+            Line::default(),
+            input_line,
+            status_line,
+            Line::default(),
+            hint_line,
+        ];
+        Paragraph::new(text).render(inner, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_editing() {
+        let mut s = TargetInputState::default();
+        for c in "8.8.8.8".chars() {
+            s.handle_char(c);
+        }
+        assert_eq!(s.input, "8.8.8.8");
+        assert_eq!(s.cursor, 7);
+
+        s.handle_backspace();
+        assert_eq!(s.input, "8.8.8.");
+        s.move_cursor_left();
+        s.move_cursor_left();
+        s.handle_delete(); // removes the '8' under the cursor at index 4
+        assert_eq!(s.input, "8.8..");
+        assert_eq!(s.cursor, 4);
+
+        // Cursor stays in bounds
+        for _ in 0..20 {
+            s.move_cursor_right();
+        }
+        assert_eq!(s.cursor, s.input.len());
+    }
+
+    #[test]
+    fn test_non_ascii_ignored() {
+        let mut s = TargetInputState::default();
+        s.handle_char('h');
+        s.handle_char('\u{00e9}'); // é: ignored, keeps byte-cursor math valid
+        s.handle_char('\t');
+        s.handle_char('x');
+        assert_eq!(s.input, "hx");
+        assert_eq!(s.cursor, 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the full **Interactive Target Selection** roadmap section: `ttl` is now a persistent network investigation tool — start empty, add and switch targets without restarting.

- `ttl` with no arguments opens an empty interactive session with an empty-state screen ("Press 'o' to add a target")
- `o` opens a target input modal (text input with cursor, background DNS resolution with a "Resolving..." state, inline errors) — available mid-session in any live TUI run, not just the empty state
- Entering an already-traced host switches to it instead of duplicating
- Headless/batch modes still require targets up front (validated in `Args::validate`)

## Architecture

- **Target-manager task** in main owns runtime growth: the TUI sends `AddTargetRequest` over an unbounded channel and polls a oneshot reply each tick (no locks shared with the render path). The manager resolves via `spawn_blocking`, enforces the same family constraints startup does (`--source-ip` family, interface address availability), creates the session with gateway/source-IP detection, and spawns the probe engine. It owns and joins everything it spawns
- **Receivers scale by IP family at runtime**: the first target of a new family spawns that family's receiver — so an empty start launches zero receivers and grows as needed
- **Receiver correlation fix**: the Echo Reply fallback previously iterated a target list cached at receiver startup; it now reads the live session map (collected before the pending-lock to keep lock ordering safe), so destination replies from dynamically added targets correlate correctly
- Empty-state safety: all `targets[selected_target]` indexing replaced with guarded access; enrichment workers already iterate the session map dynamically and needed no changes

## Verification

- 251 tests passing (11 new: input editing/cursor bounds, non-ASCII rejection, empty-target validation matrix); fmt + clippy clean
- **Live-tested in tmux + docker** (real raw sockets, real DNS): empty state renders → `o` modal → typed `1.1.1.1` → full trace with rDNS/ASN enrichment appeared (proving runtime receiver spawn from a zero-receiver start) → added `8.8.8.8` mid-session (proving dynamic correlation with a pre-existing receiver) → `[2/2]` indicator, Tab switching, and the `l` target list all correct → invalid hostname showed the resolver error inline → `q` exited cleanly