### PR TITLE
fix: prevent arithmetic panics on clock jumps and oversized packets

### DIFF
--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -135,7 +135,7 @@ impl IxCache {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        now - self.fetched_at > Self::MAX_AGE_SECS
+        now.saturating_sub(self.fetched_at) > Self::MAX_AGE_SECS
     }
 }
 
@@ -365,7 +365,7 @@ impl IxLookup {
                 .unwrap_or_default()
                 .as_secs();
             let last_fail = self.last_failure.load(Ordering::Relaxed);
-            if last_fail > 0 && now - last_fail < LOAD_FAILURE_BACKOFF_SECS {
+            if last_fail > 0 && now.saturating_sub(last_fail) < LOAD_FAILURE_BACKOFF_SECS {
                 // Still in backoff period, skip loading
                 return None;
             }
@@ -632,7 +632,7 @@ impl IxLookup {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            now - fetched_at > IxCache::MAX_AGE_SECS
+            now.saturating_sub(fetched_at) > IxCache::MAX_AGE_SECS
         } else {
             false
         };
@@ -924,6 +924,21 @@ mod tests {
             prefixes: vec![],
         };
         assert!(old.is_expired());
+    }
+
+    #[test]
+    fn test_ix_cache_future_fetched_at_does_not_panic() {
+        // fetched_at in the future should not panic (saturating_sub returns 0)
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let future = IxCache {
+            version: IxCache::VERSION,
+            fetched_at: now + 3600,
+            prefixes: vec![],
+        };
+        assert!(!future.is_expired());
     }
 
     #[test]

--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -176,9 +176,14 @@ pub fn build_ipv4_packet(
     dont_fragment: bool,
     transport: &[u8],
 ) -> Vec<u8> {
-    let total_len = (IPV4_HEADER_SIZE + transport.len()) as u16;
+    let total_payload = IPV4_HEADER_SIZE + transport.len();
+    assert!(
+        total_payload <= u16::MAX as usize,
+        "IPv4 packet too large: {total_payload} bytes (max 65535)"
+    );
+    let total_len = total_payload as u16;
     let header = build_ipv4_header(src, dst, protocol, ttl, tos, total_len, 0, dont_fragment);
-    let mut packet = Vec::with_capacity(IPV4_HEADER_SIZE + transport.len());
+    let mut packet = Vec::with_capacity(total_payload);
     packet.extend_from_slice(&header);
     packet.extend_from_slice(transport);
     packet
@@ -387,6 +392,39 @@ mod tests {
                 HDRINCL_HOST_ORDER_LEN_OFF
             ),
             "total length"
+        );
+    }
+
+    #[test]
+    fn test_build_ipv4_packet_max_size() {
+        // Transport that fills exactly to u16::MAX
+        let max_transport = u16::MAX as usize - IPV4_HEADER_SIZE;
+        let transport = vec![0u8; max_transport];
+        let pkt = build_ipv4_packet(
+            Ipv4Addr::new(1, 2, 3, 4),
+            Ipv4Addr::new(5, 6, 7, 8),
+            IPPROTO_ICMP,
+            64,
+            0,
+            false,
+            &transport,
+        );
+        assert_eq!(pkt.len(), u16::MAX as usize);
+    }
+
+    #[test]
+    #[should_panic(expected = "IPv4 packet too large")]
+    fn test_build_ipv4_packet_oversized_panics() {
+        let oversized = u16::MAX as usize - IPV4_HEADER_SIZE + 1;
+        let transport = vec![0u8; oversized];
+        build_ipv4_packet(
+            Ipv4Addr::new(1, 2, 3, 4),
+            Ipv4Addr::new(5, 6, 7, 8),
+            IPPROTO_ICMP,
+            64,
+            0,
+            false,
+            &transport,
         );
     }
 

--- a/src/trace/engine.rs
+++ b/src/trace/engine.rs
@@ -1438,7 +1438,7 @@ impl ProbeEngine {
                     };
 
                     if let Some(probe) = probe_opt {
-                        let rtt = Instant::now().duration_since(probe.sent_at);
+                        let rtt = Instant::now().saturating_duration_since(probe.sent_at);
                         let is_pmtud_probe = probe.packet_size.is_some();
 
                         // Record response (sent counting already happened at send time)

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -258,7 +258,7 @@ impl Receiver {
                                 }
                             }
                             if let Some(probe) = found_probe {
-                                let rtt = Instant::now().duration_since(probe.sent_at);
+                                let rtt = Instant::now().saturating_duration_since(probe.sent_at);
 
                                 // Collect for batched state update
                                 batch.push(BatchedResponse {
@@ -463,7 +463,7 @@ impl Receiver {
 
                     // Key is (ProbeId, flow_id, target, is_pmtud) tuple
                     pending.retain(|key, probe| {
-                        if now.duration_since(probe.sent_at) > timeout {
+                        if now.saturating_duration_since(probe.sent_at) > timeout {
                             timed_out.push((*key, probe.clone()));
                             false
                         } else {


### PR DESCRIPTION
## Summary

Prevents arithmetic panics caused by clock jumps (VM migration, hypervisor time-sync) and oversized packet construction.

## Changes

- **#19 (low):** Use `saturating_duration_since` instead of `duration_since` in receiver RTT calculation (L261), timeout cleanup (L466), **and** engine.rs IPv6 Echo Reply polling (L1441). Prevents receiver/engine-thread panic if the monotonic clock moves backward relative to a stored `Instant`. (Rebase picked up the engine.rs site flagged in review — now all three `Instant::now().duration_since` sites are converted.)
- **#13 (medium):** Use `saturating_sub` in PeeringDB cache expiry (`is_expired`), cache status display, and backoff period checks. Prevents `u64` underflow panic if `fetched_at` or `last_failure` timestamp is somehow in the future (clock jump, corrupt cache).
- **#23 (low):** Add `assert!` in `build_ipv4_packet` to catch IPv4 `total_len` `u16` wrap on oversized transport payloads instead of silently truncating the length field.

## Testing

- All 551 tests pass (including 3 new)
- `cargo clippy --all-targets -- -D warnings` clean
- New tests: `test_build_ipv4_packet_max_size` (exactly u16::MAX), `test_build_ipv4_packet_oversized_panics` (should_panic), `test_ix_cache_future_fetched_at_does_not_panic`

## Risk

Low — mechanical saturating/checked arithmetic replacements, no logic changes. Rebased onto current master; conflict in `receiver.rs` timeout-cleanup block resolved by keeping master's refactored structure and applying `saturating_duration_since`.