### PR TITLE
fix: harden unsafe socket code against alignment UB and bad cmsg

### DIFF
--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -508,6 +508,7 @@ mod tests {
                 Ok(n) => n,
                 Err(_) => break, // timeout
             };
+            // SAFETY: recv() initializes the first `n` bytes of buf.
             let data: &[u8] = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, n) };
             if data.len() < IPV4_HEADER_SIZE + 8 || data[0] >> 4 != 4 {
                 continue;

--- a/src/probe/socket.rs
+++ b/src/probe/socket.rs
@@ -486,8 +486,12 @@ pub fn recv_icmp_with_ttl(socket: &Socket, buffer: &mut [u8], ipv6: bool) -> Res
         iov_len: buffer.len(),
     };
 
-    // Allocate control message buffer (for TTL)
-    let mut cmsg_buf = [0u8; 64];
+    // Allocate control message buffer (for TTL).
+    // cmsghdr requires alignment: 8-byte on Linux/FreeBSD, 4-byte on macOS/NetBSD.
+    // Using #[repr(align(8))] ensures the buffer is suitably aligned on all platforms.
+    #[repr(align(8))]
+    struct AlignedBuf([u8; 64]);
+    let mut cmsg_buf = AlignedBuf([0u8; 64]);
 
     // Source address storage
     let mut src_storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
@@ -498,9 +502,9 @@ pub fn recv_icmp_with_ttl(socket: &Socket, buffer: &mut [u8], ipv6: bool) -> Res
     msg.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
-    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_control = cmsg_buf.0.as_mut_ptr() as *mut libc::c_void;
     // msg_controllen type differs: usize on Linux, u32 on macOS
-    msg.msg_controllen = cmsg_buf.len() as _;
+    msg.msg_controllen = cmsg_buf.0.len() as _;
 
     // Receive the packet
     let len = unsafe { libc::recvmsg(socket.as_raw_fd(), &mut msg, 0) };
@@ -557,26 +561,34 @@ fn extract_ttl_from_cmsg(msg: &libc::msghdr, ipv6: bool) -> Option<u8> {
     // IPV6_HOPLIMIT: use libc where available, define locally for NetBSD
     #[cfg(not(target_os = "netbsd"))]
     let ipv6_hoplimit = libc::IPV6_HOPLIMIT;
-    #[cfg(target_os = "netbsd")]
-    let ipv6_hoplimit: libc::c_int = 47;
-
     unsafe {
         let mut cmsg = libc::CMSG_FIRSTHDR(msg);
         while !cmsg.is_null() {
-            let hdr = &*cmsg;
+            // Read header fields with read_unaligned — CMSG pointers may not be
+            // suitably aligned for a direct reference on all platforms.
+            let cmsg_level = std::ptr::addr_of!((*cmsg).cmsg_level).read_unaligned();
+            let cmsg_type = std::ptr::addr_of!((*cmsg).cmsg_type).read_unaligned();
+            let cmsg_len = std::ptr::addr_of!((*cmsg).cmsg_len).read_unaligned();
+
+            // Validate cmsg_len is large enough to hold the TTL/hop-limit integer
+            let min_len = libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as u32) as usize;
+            if cmsg_len < min_len {
+                cmsg = libc::CMSG_NXTHDR(msg, cmsg);
+                continue;
+            }
 
             if ipv6 {
                 // IPV6_HOPLIMIT
-                if hdr.cmsg_level == libc::IPPROTO_IPV6 && hdr.cmsg_type == ipv6_hoplimit {
+                if cmsg_level == libc::IPPROTO_IPV6 && cmsg_type == ipv6_hoplimit {
                     let data_ptr = libc::CMSG_DATA(cmsg);
-                    let ttl = *(data_ptr as *const i32);
+                    let ttl = std::ptr::read_unaligned(data_ptr as *const i32);
                     return Some(ttl as u8);
                 }
             } else {
                 // IP_TTL - check platform-specific type(s)
-                if hdr.cmsg_level == libc::IPPROTO_IP && is_ip_ttl_type(hdr.cmsg_type) {
+                if cmsg_level == libc::IPPROTO_IP && is_ip_ttl_type(cmsg_type) {
                     let data_ptr = libc::CMSG_DATA(cmsg);
-                    let ttl = *(data_ptr as *const i32);
+                    let ttl = std::ptr::read_unaligned(data_ptr as *const i32);
                     return Some(ttl as u8);
                 }
             }

--- a/src/probe/socket.rs
+++ b/src/probe/socket.rs
@@ -561,6 +561,8 @@ fn extract_ttl_from_cmsg(msg: &libc::msghdr, ipv6: bool) -> Option<u8> {
     // IPV6_HOPLIMIT: use libc where available, define locally for NetBSD
     #[cfg(not(target_os = "netbsd"))]
     let ipv6_hoplimit = libc::IPV6_HOPLIMIT;
+    #[cfg(target_os = "netbsd")]
+    let ipv6_hoplimit: libc::c_int = 47;
     unsafe {
         let mut cmsg = libc::CMSG_FIRSTHDR(msg);
         while !cmsg.is_null() {
@@ -568,7 +570,7 @@ fn extract_ttl_from_cmsg(msg: &libc::msghdr, ipv6: bool) -> Option<u8> {
             // suitably aligned for a direct reference on all platforms.
             let cmsg_level = std::ptr::addr_of!((*cmsg).cmsg_level).read_unaligned();
             let cmsg_type = std::ptr::addr_of!((*cmsg).cmsg_type).read_unaligned();
-            let cmsg_len = std::ptr::addr_of!((*cmsg).cmsg_len).read_unaligned();
+            let cmsg_len = std::ptr::addr_of!((*cmsg).cmsg_len).read_unaligned() as usize;
 
             // Validate cmsg_len is large enough to hold the TTL/hop-limit integer
             let min_len = libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as u32) as usize;


### PR DESCRIPTION
## Summary

Hardens unsafe socket code to eliminate alignment UB and out-of-bounds reads in the ICMP receiver's ancillary-data (CMSG) handling.

## Changes

- **#4 (high):** Replace 1-byte-aligned `[u8; 64]` cmsg buffer with a `#[repr(align(8))]` wrapper to satisfy `struct cmsghdr` alignment requirements (8-byte on Linux/FreeBSD, 4-byte on macOS/NetBSD).
- **#4 (high):** Replace `&*cmsg` dereferences with `ptr::addr_of!` + `read_unaligned` for `cmsg_level`, `cmsg_type`, `cmsg_len`, and the TTL/hop-limit integer — eliminating unaligned reference UB that works on x86 only by hardware tolerance.
- **#27 (low):** Validate `cmsg_len >= CMSG_LEN(sizeof(c_int))` before reading the TTL integer, preventing read past the cmsg boundary on malformed/truncated ancillary data.
- **#33 (low):** Add explicit SAFETY comment documenting that `recv()` initializes the first `n` bytes before `from_raw_parts` is called on the `MaybeUninit` buffer in the raw-socket test.

## Testing

- All 493 tests pass; `cargo clippy --all-targets -- -D warnings` clean.
- The `#[repr(align(8))]` struct is defined inline in `recv_icmp_with_ttl` — no public API change.

## Risk

Medium — touches `unsafe` code in the ICMP receive path, but the changes are mechanical: aligned buffer + `read_unaligned` + bounds check. No logic changes.
