### PR TITLE
fix: file security and output hygiene

### DIFF
--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -89,7 +89,7 @@ pub fn export_csv<W: Write>(session: &Session, mut writer: W) -> Result<()> {
     Ok(())
 }
 
-/// Escape a string for CSV (quote if contains comma, quote, or newline)
+/// Escape a string for CSV (quote if contains comma, quote, newline, or carriage return)
 fn escape_csv(s: &str) -> String {
     if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
         format!("\"{}\"", s.replace('"', "\"\""))

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -91,7 +91,7 @@ pub fn export_csv<W: Write>(session: &Session, mut writer: W) -> Result<()> {
 
 /// Escape a string for CSV (quote if contains comma, quote, or newline)
 fn escape_csv(s: &str) -> String {
-    if s.contains(',') || s.contains('"') || s.contains('\n') {
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
         format!("\"{}\"", s.replace('"', "\"\""))
     } else {
         s.to_string()

--- a/src/export/json.rs
+++ b/src/export/json.rs
@@ -15,14 +15,31 @@ pub fn export_json_string(session: &Session) -> Result<String> {
     Ok(serde_json::to_string_pretty(session)?)
 }
 
-/// Export session to file with auto-generated name
+/// Export session to file with auto-generated name.
+/// The target name is sanitized to prevent path traversal.
 pub fn export_json_file(session: &Session) -> Result<String> {
     let timestamp = session.started_at.format("%Y%m%d-%H%M%S");
-    let target = &session.target.original;
+    let target = sanitize_filename(&session.target.original);
     let filename = format!("ttl-{}-{}.json", target, timestamp);
 
     let file = std::fs::File::create(&filename)?;
     export_json(session, file)?;
 
     Ok(filename)
+}
+
+/// Sanitize a string for safe use as a filename component.
+/// Replaces path separators, control characters, and other unsafe chars with `_`.
+fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_control()
+                || matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|')
+            {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect()
 }

--- a/src/export/json.rs
+++ b/src/export/json.rs
@@ -31,15 +31,76 @@ pub fn export_json_file(session: &Session) -> Result<String> {
 /// Sanitize a string for safe use as a filename component.
 /// Replaces path separators, control characters, and other unsafe chars with `_`.
 fn sanitize_filename(s: &str) -> String {
-    s.chars()
+    let mut sanitized: String = s
+        .chars()
         .map(|c| {
-            if c.is_ascii_control()
-                || matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|')
-            {
+            if c.is_control() || matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|') {
                 '_'
             } else {
                 c
             }
         })
-        .collect()
+        .collect();
+
+    sanitized.truncate(sanitized.trim_end_matches([' ', '.']).len());
+    if sanitized.is_empty() {
+        return "_".to_string();
+    }
+
+    let base_name = sanitized
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    if matches!(
+        base_name.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    ) {
+        sanitized.insert(0, '_');
+    }
+
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_filename_replaces_path_and_control_chars() {
+        assert_eq!(
+            sanitize_filename("a/b\\c:d*e?f\"g<h>i|j"),
+            "a_b_c_d_e_f_g_h_i_j"
+        );
+        assert_eq!(sanitize_filename("host\u{0085}name"), "host_name");
+    }
+
+    #[test]
+    fn test_sanitize_filename_handles_windows_invalid_components() {
+        assert_eq!(sanitize_filename("CON"), "_CON");
+        assert_eq!(sanitize_filename("nul.txt"), "_nul.txt");
+        assert_eq!(sanitize_filename("router. "), "router");
+        assert_eq!(sanitize_filename("..."), "_");
+    }
 }

--- a/src/export/report.rs
+++ b/src/export/report.rs
@@ -1,16 +1,12 @@
 use std::io::Write;
 
+use crate::lookup::sanitize_display;
 use crate::state::Session;
 
 /// Generate a text report similar to mtr --report
 pub fn generate_report<W: Write>(session: &Session, mut writer: W) -> std::io::Result<()> {
     // Sanitize user-supplied strings to prevent terminal output injection
-    let target_orig = session
-        .target
-        .original
-        .chars()
-        .filter(|c| !c.is_control())
-        .collect::<String>();
+    let target_orig = sanitize_display(&session.target.original);
     let target_resolved = session.target.resolved.to_string();
     writeln!(
         writer,
@@ -23,7 +19,7 @@ pub fn generate_report<W: Write>(session: &Session, mut writer: W) -> std::io::R
         session.started_at.format("%Y-%m-%d %H:%M:%S UTC")
     )?;
     if let Some(ref iface) = session.config.interface {
-        let safe_iface: String = iface.chars().filter(|c| !c.is_control()).collect();
+        let safe_iface = sanitize_display(iface);
         writeln!(writer, "Interface: {}", safe_iface)?;
     }
     writeln!(writer)?;

--- a/src/export/report.rs
+++ b/src/export/report.rs
@@ -4,10 +4,18 @@ use crate::state::Session;
 
 /// Generate a text report similar to mtr --report
 pub fn generate_report<W: Write>(session: &Session, mut writer: W) -> std::io::Result<()> {
+    // Sanitize user-supplied strings to prevent terminal output injection
+    let target_orig = session
+        .target
+        .original
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>();
+    let target_resolved = session.target.resolved.to_string();
     writeln!(
         writer,
         "ttl report for {} ({})",
-        session.target.original, session.target.resolved
+        target_orig, target_resolved
     )?;
     writeln!(
         writer,
@@ -15,7 +23,8 @@ pub fn generate_report<W: Write>(session: &Session, mut writer: W) -> std::io::R
         session.started_at.format("%Y-%m-%d %H:%M:%S UTC")
     )?;
     if let Some(ref iface) = session.config.interface {
-        writeln!(writer, "Interface: {}", iface)?;
+        let safe_iface: String = iface.chars().filter(|c| !c.is_control()).collect();
+        writeln!(writer, "Interface: {}", safe_iface)?;
     }
     writeln!(writer)?;
 

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -21,6 +21,8 @@ use super::sanitize_display;
 use crate::state::IxInfo;
 use crate::trace::receiver::SessionMap;
 
+static CACHE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 fn rename_cache_file(temp: &Path, dest: &Path) -> Result<()> {
     #[cfg(windows)]
     {
@@ -457,7 +459,12 @@ impl IxLookup {
             .cache_path
             .parent()
             .ok_or_else(|| anyhow!("cache path has no parent directory"))?;
-        let temp = parent.join(format!(".peeringdb_cache.{}.tmp", std::process::id()));
+        let nonce = CACHE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp = parent.join(format!(
+            ".peeringdb_cache.{}.{}.tmp",
+            std::process::id(),
+            nonce
+        ));
         fs::write(&temp, &data)?;
 
         let result = rename_cache_file(&temp, &self.cache_path);
@@ -656,8 +663,8 @@ impl IxLookup {
         let this = Arc::clone(self);
         tokio::spawn(async move {
             // RAII guard ensures refreshing is reset even if the task panics
-            let _guard = scopeguard::guard((), |_| {
-                this.refreshing.store(false, Ordering::SeqCst);
+            let _guard = scopeguard::guard(Arc::clone(&this), |lookup| {
+                lookup.refreshing.store(false, Ordering::SeqCst);
             });
             let result = this.refresh_cache_inner().await;
             if let Err(_e) = result {

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -6,7 +6,6 @@
 use anyhow::{Result, anyhow};
 use ipnetwork::IpNetwork;
 use parking_lot::RwLock;
-use scopeguard;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -409,8 +408,17 @@ impl IxLookup {
             .cache_path
             .parent()
             .ok_or_else(|| anyhow!("cache path has no parent directory"))?;
-        let temp = parent.join(".peeringdb_cache.tmp");
+        let temp = parent.join(format!(".peeringdb_cache.{}.tmp", std::process::id()));
         fs::write(&temp, &data)?;
+
+        // std::fs::rename does not overwrite existing files on Windows.
+        #[cfg(windows)]
+        match fs::remove_file(&self.cache_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+
         fs::rename(&temp, &self.cache_path)?;
         Ok(())
     }

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -6,6 +6,7 @@
 use anyhow::{Result, anyhow};
 use ipnetwork::IpNetwork;
 use parking_lot::RwLock;
+use scopeguard;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -401,10 +402,16 @@ impl IxLookup {
         Ok(cache)
     }
 
-    /// Save cache to disk
+    /// Save cache to disk atomically (write to temp file, then rename)
     fn save_cache(&self, cache: &IxCache) -> Result<()> {
         let data = serde_json::to_string_pretty(cache)?;
-        fs::write(&self.cache_path, data)?;
+        let parent = self
+            .cache_path
+            .parent()
+            .ok_or_else(|| anyhow!("cache path has no parent directory"))?;
+        let temp = parent.join(".peeringdb_cache.tmp");
+        fs::write(&temp, &data)?;
+        fs::rename(&temp, &self.cache_path)?;
         Ok(())
     }
 
@@ -589,15 +596,13 @@ impl IxLookup {
     /// This spawns a background task to fetch fresh data from PeeringDB.
     /// The refreshing flag is set while the operation is in progress.
     pub fn refresh_cache(self: &Arc<Self>) {
-        if self.refreshing.swap(true, Ordering::SeqCst) {
-            // Already refreshing
-            return;
-        }
-
         let this = Arc::clone(self);
         tokio::spawn(async move {
+            // RAII guard ensures refreshing is reset even if the task panics
+            let _guard = scopeguard::guard((), |_| {
+                this.refreshing.store(false, Ordering::SeqCst);
+            });
             let result = this.refresh_cache_inner().await;
-            this.refreshing.store(false, Ordering::SeqCst);
             if let Err(_e) = result {
                 // Silent failure - IX detection is optional enrichment
                 // Store failure time for backoff

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::net::IpAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime};
@@ -20,6 +20,28 @@ use tokio_util::sync::CancellationToken;
 use super::sanitize_display;
 use crate::state::IxInfo;
 use crate::trace::receiver::SessionMap;
+
+fn rename_cache_file(temp: &Path, dest: &Path) -> Result<()> {
+    #[cfg(windows)]
+    {
+        match fs::rename(temp, dest) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Windows rename does not replace existing destinations.
+                fs::remove_file(dest)?;
+                fs::rename(temp, dest)?;
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        fs::rename(temp, dest)?;
+        Ok(())
+    }
+}
 
 /// PeeringDB API response wrapper
 #[derive(Debug, Deserialize)]
@@ -401,7 +423,7 @@ impl IxLookup {
         Ok(cache)
     }
 
-    /// Save cache to disk atomically (write to temp file, then rename)
+    /// Save cache to disk via temp file then rename.
     fn save_cache(&self, cache: &IxCache) -> Result<()> {
         let data = serde_json::to_string_pretty(cache)?;
         let parent = self
@@ -411,16 +433,11 @@ impl IxLookup {
         let temp = parent.join(format!(".peeringdb_cache.{}.tmp", std::process::id()));
         fs::write(&temp, &data)?;
 
-        // std::fs::rename does not overwrite existing files on Windows.
-        #[cfg(windows)]
-        match fs::remove_file(&self.cache_path) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => return Err(e.into()),
+        let result = rename_cache_file(&temp, &self.cache_path);
+        if result.is_err() {
+            let _ = fs::remove_file(&temp);
         }
-
-        fs::rename(&temp, &self.cache_path)?;
-        Ok(())
+        result
     }
 
     /// Populate prefixes from cache

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -596,6 +596,11 @@ impl IxLookup {
     /// This spawns a background task to fetch fresh data from PeeringDB.
     /// The refreshing flag is set while the operation is in progress.
     pub fn refresh_cache(self: &Arc<Self>) {
+        if !self.try_begin_refresh() {
+            // Already refreshing
+            return;
+        }
+
         let this = Arc::clone(self);
         tokio::spawn(async move {
             // RAII guard ensures refreshing is reset even if the task panics
@@ -613,6 +618,10 @@ impl IxLookup {
                 this.last_failure.store(now, Ordering::Relaxed);
             }
         });
+    }
+
+    fn try_begin_refresh(&self) -> bool {
+        !self.refreshing.swap(true, Ordering::SeqCst)
     }
 
     /// Inner refresh logic
@@ -737,6 +746,34 @@ mod tests {
         table
             .lookup(ip.parse().unwrap())
             .map(|info| info.name.clone())
+    }
+
+    fn test_lookup() -> IxLookup {
+        IxLookup {
+            prefixes: RwLock::new(PrefixTable::new()),
+            cache_path: std::env::temp_dir()
+                .join(format!("ix_refresh_gate_{}.json", std::process::id())),
+            load_once: OnceCell::new(),
+            last_failure: AtomicU64::new(0),
+            ip_cache: RwLock::new(HashMap::new()),
+            ip_cache_ttl: Duration::from_secs(3600),
+            ip_cache_times: RwLock::new(HashMap::new()),
+            api_key: RwLock::new(None),
+            cache_fetched_at: AtomicU64::new(0),
+            refreshing: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn test_try_begin_refresh_sets_flag_and_deduplicates() {
+        let lookup = test_lookup();
+
+        assert!(lookup.try_begin_refresh());
+        assert!(lookup.refreshing.load(Ordering::SeqCst));
+        assert!(!lookup.try_begin_refresh());
+
+        lookup.refreshing.store(false, Ordering::SeqCst);
+        assert!(lookup.try_begin_refresh());
     }
 
     #[test]

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -28,9 +28,36 @@ fn rename_cache_file(temp: &Path, dest: &Path) -> Result<()> {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 // Windows rename does not replace existing destinations.
-                fs::remove_file(dest)?;
-                fs::rename(temp, dest)?;
-                Ok(())
+                let backup = dest.with_file_name(format!(
+                    ".{}.{}.bak",
+                    dest.file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("ix_cache"),
+                    std::process::id()
+                ));
+                match fs::remove_file(&backup) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                }
+
+                fs::rename(dest, &backup)?;
+                match fs::rename(temp, dest) {
+                    Ok(()) => {
+                        let _ = fs::remove_file(&backup);
+                        Ok(())
+                    }
+                    Err(replace_err) => {
+                        if let Err(restore_err) = fs::rename(&backup, dest) {
+                            return Err(anyhow!(
+                                "failed to replace cache file: {}; also failed to restore previous cache: {}",
+                                replace_err,
+                                restore_err
+                            ));
+                        }
+                        Err(replace_err.into())
+                    }
+                }
             }
             Err(e) => Err(e.into()),
         }

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -58,7 +58,7 @@ impl Prefs {
     }
 
     /// Load preferences from disk. Logs a warning on corrupt files instead of
-    /// silently resetting — the caller decides whether to surface it.
+    /// silently resetting.
     pub fn load() -> Self {
         match Self::path() {
             Some(path) => match fs::read_to_string(&path) {
@@ -86,13 +86,26 @@ impl Prefs {
                 fs::create_dir_all(parent)?;
             }
             let data = toml::to_string_pretty(self)?;
-            fs::write(&path, data)?;
-
-            // Restrict file permissions to owner-only (protect API keys)
             #[cfg(unix)]
             {
-                use std::os::unix::fs::PermissionsExt;
+                use std::fs::OpenOptions;
+                use std::io::Write;
+                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&path)?;
+                file.write_all(data.as_bytes())?;
+
+                // Enforce owner-only permissions for existing files too.
                 fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+            }
+            #[cfg(not(unix))]
+            {
+                fs::write(&path, data)?;
             }
         }
         Ok(())

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -57,21 +57,43 @@ impl Prefs {
         dirs::config_dir().map(|p| p.join("ttl").join("config.toml"))
     }
 
-    /// Load preferences from disk (returns default if missing/invalid)
+    /// Load preferences from disk. Logs a warning on corrupt files instead of
+    /// silently resetting — the caller decides whether to surface it.
     pub fn load() -> Self {
-        Self::path()
-            .and_then(|p| fs::read_to_string(p).ok())
-            .and_then(|s| toml::from_str(&s).ok())
-            .unwrap_or_default()
+        match Self::path() {
+            Some(path) => match fs::read_to_string(&path) {
+                Ok(s) => match toml::from_str(&s) {
+                    Ok(prefs) => prefs,
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: could not parse preferences at {}: {}",
+                            path.display(),
+                            e
+                        );
+                        Self::default()
+                    }
+                },
+                Err(_) => Self::default(),
+            },
+            None => Self::default(),
+        }
     }
 
-    /// Save preferences to disk
+    /// Save preferences to disk with restrictive permissions (0600 on Unix).
     pub fn save(&self) -> anyhow::Result<()> {
         if let Some(path) = Self::path() {
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent)?;
             }
-            fs::write(path, toml::to_string_pretty(self)?)?;
+            let data = toml::to_string_pretty(self)?;
+            fs::write(&path, data)?;
+
+            // Restrict file permissions to owner-only (protect API keys)
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+            }
         }
         Ok(())
     }

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -73,7 +73,15 @@ impl Prefs {
                         Self::default()
                     }
                 },
-                Err(_) => Self::default(),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::default(),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not read preferences at {}: {}",
+                        path.display(),
+                        e
+                    );
+                    Self::default()
+                }
             },
             None => Self::default(),
         }
@@ -92,6 +100,12 @@ impl Prefs {
                 use std::io::Write;
                 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
+                match fs::metadata(&path) {
+                    Ok(_) => fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                }
+
                 let mut file = OpenOptions::new()
                     .write(true)
                     .create(true)
@@ -99,6 +113,7 @@ impl Prefs {
                     .mode(0o600)
                     .open(&path)?;
                 file.write_all(data.as_bytes())?;
+                file.sync_all()?;
 
                 // Enforce owner-only permissions for existing files too.
                 fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;


### PR DESCRIPTION
## Summary

Improves file security, prevents path traversal, and hardens output hygiene.

## Changes

- **#14 (medium):** Set prefs file permissions to 0600 on Unix after writing, protecting the PeeringDB API key from other users. Surface corrupt prefs parse errors as warnings instead of silently resetting settings.
- **#15 (medium):** Sanitize target name in JSON export filename (`sanitize_filename` replaces path separators, control chars, and unsafe filename chars with `_`), preventing path traversal via crafted target names or replay files.
- **#24 (low):** Quote CSV fields containing `\r` for RFC 4180 line-break compliance (was only checking `,`, `"`, `\n`).
- **#25 (low):** Write PeeringDB cache atomically (temp file + rename) to prevent corruption on crash.
- **#26 (low):** Use `scopeguard` to reset the `refreshing` flag even if the refresh task panics, preventing permanent refresh lockout.
- **#28 (low):** Sanitize control characters in report target/interface output to prevent terminal/log output injection.

## Testing

- All 493 tests pass; `cargo clippy --all-targets -- -D warnings` clean.

## Risk

Low — file I/O and output formatting only, no networking or probe-sending changes.
