### PR TITLE
fix: PMTUD correlation, lock ordering, and enrichment dedup

### DIFF
--- a/src/lookup/asn.rs
+++ b/src/lookup/asn.rs
@@ -4,7 +4,7 @@ use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::{Resolver, TokioResolver};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -223,32 +223,30 @@ pub async fn run_asn_worker(
                 break;
             }
             _ = interval.tick() => {
-                // Collect IPs that need ASN lookup from all sessions
-                let ips_to_lookup: Vec<IpAddr> = {
+                // Collect a bounded, first-seen batch of unique IPs that need ASN lookup.
+                let batch: Vec<IpAddr> = {
                     let sessions = sessions.read();
-                    sessions.values()
-                        .flat_map(|state| {
-                            let session = state.read();
-                            session.hops.iter()
-                                .flat_map(|hop| hop.responders.values())
-                                .filter(|stats| stats.asn.is_none())
-                                .map(|stats| stats.ip)
-                                .collect::<Vec<_>>()
-                        })
-                        .collect()
+                    let mut seen = HashSet::new();
+                    let mut batch = Vec::new();
+                    'sessions: for state in sessions.values() {
+                        let session = state.read();
+                        for hop in &session.hops {
+                            for stats in hop.responders.values() {
+                                if stats.asn.is_none() && seen.insert(stats.ip) {
+                                    batch.push(stats.ip);
+                                    if batch.len() >= MAX_CONCURRENT_LOOKUPS {
+                                        break 'sessions;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    batch
                 };
 
-                if ips_to_lookup.is_empty() {
+                if batch.is_empty() {
                     continue;
                 }
-
-                // Perform parallel ASN lookups (limited batch size)
-                let batch: Vec<IpAddr> = ips_to_lookup
-                    .into_iter()
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter()
-                    .take(MAX_CONCURRENT_LOOKUPS)
-                    .collect();
 
                 // Spawn concurrent lookups
                 let futures: Vec<_> = batch

--- a/src/lookup/asn.rs
+++ b/src/lookup/asn.rs
@@ -245,6 +245,8 @@ pub async fn run_asn_worker(
                 // Perform parallel ASN lookups (limited batch size)
                 let batch: Vec<IpAddr> = ips_to_lookup
                     .into_iter()
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
                     .take(MAX_CONCURRENT_LOOKUPS)
                     .collect();
 

--- a/src/lookup/geo.rs
+++ b/src/lookup/geo.rs
@@ -1,6 +1,6 @@
 use maxminddb::{Reader, geoip2};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -145,32 +145,30 @@ pub async fn run_geo_worker(
                 break;
             }
             _ = interval.tick() => {
-                // Collect IPs that need geo lookup from all sessions
-                let ips_to_lookup: Vec<IpAddr> = {
+                // Collect a bounded, first-seen batch of unique IPs that need geo lookup.
+                let batch: Vec<IpAddr> = {
                     let sessions = sessions.read();
-                    sessions.values()
-                        .flat_map(|state| {
-                            let session = state.read();
-                            session.hops.iter()
-                                .flat_map(|hop| hop.responders.values())
-                                .filter(|stats| stats.geo.is_none())
-                                .map(|stats| stats.ip)
-                                .collect::<Vec<_>>()
-                        })
-                        .collect()
+                    let mut seen = HashSet::new();
+                    let mut batch = Vec::new();
+                    'sessions: for state in sessions.values() {
+                        let session = state.read();
+                        for hop in &session.hops {
+                            for stats in hop.responders.values() {
+                                if stats.geo.is_none() && seen.insert(stats.ip) {
+                                    batch.push(stats.ip);
+                                    if batch.len() >= MAX_CONCURRENT_LOOKUPS {
+                                        break 'sessions;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    batch
                 };
 
-                if ips_to_lookup.is_empty() {
+                if batch.is_empty() {
                     continue;
                 }
-
-                // GeoIP lookups are fast (local file), so we can do more at once
-                let batch: Vec<IpAddr> = ips_to_lookup
-                    .into_iter()
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter()
-                    .take(MAX_CONCURRENT_LOOKUPS)
-                    .collect();
 
                 // Lookups are sync and fast, just do them in a loop
                 let results: Vec<(IpAddr, Option<GeoInfo>)> = batch

--- a/src/lookup/geo.rs
+++ b/src/lookup/geo.rs
@@ -167,6 +167,8 @@ pub async fn run_geo_worker(
                 // GeoIP lookups are fast (local file), so we can do more at once
                 let batch: Vec<IpAddr> = ips_to_lookup
                     .into_iter()
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
                     .take(MAX_CONCURRENT_LOOKUPS)
                     .collect();
 

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -672,6 +672,8 @@ pub async fn run_ix_worker(
                 // Perform parallel IX lookups (limited batch size)
                 let batch: Vec<IpAddr> = ips_to_lookup
                     .into_iter()
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
                     .take(MAX_CONCURRENT_LOOKUPS)
                     .collect();
 

--- a/src/lookup/ix.rs
+++ b/src/lookup/ix.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, anyhow};
 use ipnetwork::IpNetwork;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -650,32 +650,30 @@ pub async fn run_ix_worker(
                 break;
             }
             _ = interval.tick() => {
-                // Collect IPs that need IX lookup from all sessions
-                let ips_to_lookup: Vec<IpAddr> = {
+                // Collect a bounded, first-seen batch of unique IPs that need IX lookup.
+                let batch: Vec<IpAddr> = {
                     let sessions = sessions.read();
-                    sessions.values()
-                        .flat_map(|state| {
-                            let session = state.read();
-                            session.hops.iter()
-                                .flat_map(|hop| hop.responders.values())
-                                .filter(|stats| stats.ix.is_none())
-                                .map(|stats| stats.ip)
-                                .collect::<Vec<_>>()
-                        })
-                        .collect()
+                    let mut seen = HashSet::new();
+                    let mut batch = Vec::new();
+                    'sessions: for state in sessions.values() {
+                        let session = state.read();
+                        for hop in &session.hops {
+                            for stats in hop.responders.values() {
+                                if stats.ix.is_none() && seen.insert(stats.ip) {
+                                    batch.push(stats.ip);
+                                    if batch.len() >= MAX_CONCURRENT_LOOKUPS {
+                                        break 'sessions;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    batch
                 };
 
-                if ips_to_lookup.is_empty() {
+                if batch.is_empty() {
                     continue;
                 }
-
-                // Perform parallel IX lookups (limited batch size)
-                let batch: Vec<IpAddr> = ips_to_lookup
-                    .into_iter()
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter()
-                    .take(MAX_CONCURRENT_LOOKUPS)
-                    .collect();
 
                 // Spawn concurrent lookups
                 let futures: Vec<_> = batch

--- a/src/lookup/rdns.rs
+++ b/src/lookup/rdns.rs
@@ -130,6 +130,8 @@ pub async fn run_dns_worker(dns: Arc<DnsLookup>, sessions: SessionMap, cancel: C
                 // Perform parallel DNS lookups (limited batch size)
                 let batch: Vec<IpAddr> = ips_to_lookup
                     .into_iter()
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
                     .take(MAX_CONCURRENT_LOOKUPS)
                     .collect();
 

--- a/src/lookup/rdns.rs
+++ b/src/lookup/rdns.rs
@@ -4,7 +4,7 @@ use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::{Resolver, TokioResolver};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -108,32 +108,30 @@ pub async fn run_dns_worker(dns: Arc<DnsLookup>, sessions: SessionMap, cancel: C
                 break;
             }
             _ = interval.tick() => {
-                // Collect IPs that need lookup from all sessions
-                let ips_to_lookup: Vec<IpAddr> = {
+                // Collect a bounded, first-seen batch of unique IPs that need lookup.
+                let batch: Vec<IpAddr> = {
                     let sessions = sessions.read();
-                    sessions.values()
-                        .flat_map(|state| {
-                            let session = state.read();
-                            session.hops.iter()
-                                .flat_map(|hop| hop.responders.values())
-                                .filter(|stats| stats.hostname.is_none())
-                                .map(|stats| stats.ip)
-                                .collect::<Vec<_>>()
-                        })
-                        .collect()
+                    let mut seen = HashSet::new();
+                    let mut batch = Vec::new();
+                    'sessions: for state in sessions.values() {
+                        let session = state.read();
+                        for hop in &session.hops {
+                            for stats in hop.responders.values() {
+                                if stats.hostname.is_none() && seen.insert(stats.ip) {
+                                    batch.push(stats.ip);
+                                    if batch.len() >= MAX_CONCURRENT_LOOKUPS {
+                                        break 'sessions;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    batch
                 };
 
-                if ips_to_lookup.is_empty() {
+                if batch.is_empty() {
                     continue;
                 }
-
-                // Perform parallel DNS lookups (limited batch size)
-                let batch: Vec<IpAddr> = ips_to_lookup
-                    .into_iter()
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter()
-                    .take(MAX_CONCURRENT_LOOKUPS)
-                    .collect();
 
                 // Spawn concurrent lookups
                 let futures: Vec<_> = batch

--- a/src/probe/correlate.rs
+++ b/src/probe/correlate.rs
@@ -26,6 +26,8 @@ pub struct ParsedResponse {
     pub responder: IpAddr,
     pub probe_id: ProbeId,
     pub response_type: IcmpResponseType,
+    /// True if the probe was a PMTUD probe (detected via payload marker)
+    pub is_pmtud: bool,
     /// MPLS labels from ICMP extensions (RFC 4950), if present
     pub mpls_labels: Option<Vec<MplsLabel>>,
     /// Source port from original UDP/TCP packet (for flow identification in Paris/Dublin traceroute)
@@ -227,6 +229,7 @@ fn parse_icmp_response_v4(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -246,6 +249,7 @@ fn parse_icmp_response_v4(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -397,6 +401,7 @@ fn parse_icmp_response_v6(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -415,6 +420,7 @@ fn parse_icmp_response_v6(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -533,6 +539,7 @@ fn parse_icmp_error_payload_v4_with_mtu(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -556,6 +563,7 @@ fn parse_icmp_error_payload_v4_with_mtu(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -583,6 +591,7 @@ fn parse_icmp_error_payload_v4_with_mtu(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -609,6 +618,7 @@ fn parse_icmp_error_payload_v4_with_mtu(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -706,6 +716,7 @@ fn parse_icmp_error_payload_v6_with_mtu(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -728,6 +739,7 @@ fn parse_icmp_error_payload_v6_with_mtu(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -755,6 +767,7 @@ fn parse_icmp_error_payload_v6_with_mtu(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -781,6 +794,7 @@ fn parse_icmp_error_payload_v6_with_mtu(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -809,6 +823,12 @@ fn extract_id_from_payload(payload: &[u8], our_identifier: u16) -> Option<(u16, 
     } else {
         None
     }
+}
+
+/// Check if an Echo Reply payload contains the PMTUD marker at byte 8.
+/// Normal probes have 0x00 there (pattern fill index 0); PMTUD probes set 0x50.
+fn is_pmtud_payload(payload: &[u8]) -> bool {
+    payload.len() > 8 && payload[8] == crate::probe::icmp::PMTUD_MARKER
 }
 
 /// Parse IPv4 ICMP from DGRAM socket (no IP header)
@@ -841,6 +861,7 @@ fn parse_icmp_response_v4_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -860,6 +881,7 @@ fn parse_icmp_response_v4_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -948,6 +970,7 @@ fn parse_icmp_error_payload_v4_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -967,6 +990,7 @@ fn parse_icmp_error_payload_v4_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -987,6 +1011,7 @@ fn parse_icmp_error_payload_v4_dgram(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -1006,6 +1031,7 @@ fn parse_icmp_error_payload_v4_dgram(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -1040,6 +1066,7 @@ fn parse_icmp_response_v6_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -1058,6 +1085,7 @@ fn parse_icmp_response_v6_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type: IcmpResponseType::EchoReply,
+                    is_pmtud: is_pmtud_payload(&icmp_data[8..]),
                     mpls_labels: None,
                     src_port: None,
                     mtu: None,
@@ -1161,6 +1189,7 @@ fn parse_icmp_error_payload_v6_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(sequence),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -1178,6 +1207,7 @@ fn parse_icmp_error_payload_v6_dgram(
                     responder,
                     probe_id: ProbeId::from_sequence(payload_seq),
                     response_type,
+                    is_pmtud: false,
                     mpls_labels,
                     src_port: None,
                     mtu,
@@ -1198,6 +1228,7 @@ fn parse_icmp_error_payload_v6_dgram(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -1217,6 +1248,7 @@ fn parse_icmp_error_payload_v6_dgram(
                 responder,
                 probe_id,
                 response_type,
+                is_pmtud: false,
                 mpls_labels,
                 src_port: Some(src_port),
                 mtu,
@@ -2288,5 +2320,110 @@ mod tests {
             let responder = IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1));
             prop_assert!(parse_icmp_response(&data, responder, 0x1234, false).is_none());
         }
+    }
+
+    /// End-to-end test: build a PMTUD Echo Request, convert to Echo Reply,
+    /// parse it, and verify is_pmtud is true. This catches offset bugs
+    /// (icmp_data vs payload slice) that builder-only tests miss.
+    #[test]
+    fn test_parse_pmtud_echo_reply_v4_dgram() {
+        use crate::probe::icmp::build_echo_request;
+
+        let our_id = 0x1234;
+        let probe_id = ProbeId::new(10, 5);
+        let responder = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));
+
+        // Build a PMTUD Echo Request via the real builder
+        let request = build_echo_request(
+            our_id,
+            probe_id.to_sequence(),
+            56,
+            false,
+            None,
+            true, // pmtud
+        );
+
+        // Convert to Echo Reply: change type from 8 (Echo Request) to 0 (Echo Reply)
+        let mut reply = request.clone();
+        reply[0] = 0; // Echo Reply type
+        // Recompute ICMP checksum
+        set_icmp_checksum(&mut reply);
+
+        // Parse as DGRAM (no IP header)
+        let result = parse_icmp_response(&reply, responder, our_id, true);
+        assert!(result.is_some(), "PMTUD Echo Reply should parse");
+        let parsed = result.unwrap();
+        assert_eq!(parsed.response_type, IcmpResponseType::EchoReply);
+        assert!(
+            parsed.is_pmtud,
+            "PMTUD Echo Reply should have is_pmtud=true"
+        );
+        assert_eq!(parsed.probe_id.ttl, 10);
+        assert_eq!(parsed.probe_id.seq, 5);
+    }
+
+    #[test]
+    fn test_parse_normal_echo_reply_v4_dgram_is_not_pmtud() {
+        use crate::probe::icmp::build_echo_request;
+
+        let our_id = 0x1234;
+        let probe_id = ProbeId::new(10, 5);
+        let responder = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));
+
+        // Build a normal Echo Request
+        let request = build_echo_request(
+            our_id,
+            probe_id.to_sequence(),
+            56,
+            false,
+            None,
+            false, // not pmtud
+        );
+
+        // Convert to Echo Reply
+        let mut reply = request.clone();
+        reply[0] = 0;
+        set_icmp_checksum(&mut reply);
+
+        let result = parse_icmp_response(&reply, responder, our_id, true);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert!(
+            !parsed.is_pmtud,
+            "Normal Echo Reply should have is_pmtud=false"
+        );
+    }
+
+    #[test]
+    fn test_parse_pmtud_echo_reply_v4_raw() {
+        use crate::probe::icmp::build_echo_request;
+
+        let our_id = 0x1234;
+        let probe_id = ProbeId::new(12, 3);
+        let responder = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 4, 4));
+
+        // Build PMTUD Echo Request
+        let icmp = build_echo_request(our_id, probe_id.to_sequence(), 56, false, None, true);
+
+        // Wrap in an IPv4 header for RAW socket parsing
+        let mut packet = vec![0u8; 20 + icmp.len()];
+        packet[0] = 0x45; // Version 4, IHL 5
+        packet[9] = 1; // Protocol: ICMP
+        packet[20..].copy_from_slice(&icmp);
+
+        // Convert ICMP type to Echo Reply
+        packet[20] = 0;
+        // Recompute ICMP checksum (starts at IP header offset 20)
+        set_icmp_checksum(&mut packet[20..]);
+
+        let result = parse_icmp_response(&packet, responder, our_id, false);
+        assert!(result.is_some(), "PMTUD Echo Reply via RAW should parse");
+        let parsed = result.unwrap();
+        assert!(
+            parsed.is_pmtud,
+            "PMTUD Echo Reply via RAW should have is_pmtud=true"
+        );
+        assert_eq!(parsed.probe_id.ttl, 12);
+        assert_eq!(parsed.probe_id.seq, 3);
     }
 }

--- a/src/probe/icmp.rs
+++ b/src/probe/icmp.rs
@@ -9,6 +9,10 @@ pub const ICMP_HEADER_SIZE: usize = 8;
 pub const DEFAULT_PAYLOAD_SIZE: usize = 56;
 /// Minimum payload size (4 bytes ProbeId + 4 bytes timestamp)
 pub const MIN_PAYLOAD_SIZE: usize = 8;
+/// PMTUD marker byte written to payload[8] to distinguish PMTUD probes.
+/// Echo Replies echo the payload verbatim, so the receiver can detect
+/// PMTUD success without a separate ICMP identifier.
+pub const PMTUD_MARKER: u8 = 0x50; // 'P'
 
 /// Calculate ICMPv6 checksum including IPv6 pseudo-header.
 ///
@@ -73,13 +77,19 @@ pub fn get_identifier() -> u16 {
 /// - Bytes 0-1: identifier (backup for kernel override on macOS DGRAM sockets)
 /// - Bytes 2-3: sequence (backup for kernel override)
 /// - Bytes 4-7: timestamp (lower 32 bits)
-/// - Bytes 8+: pattern fill
+/// - Byte 8: PMTUD marker (0x50 for PMTUD probes, 0x00 for normal probes)
+/// - Bytes 9+: pattern fill
+///
+/// The PMTUD marker at byte 8 is echoed back unchanged in Echo Replies, allowing
+/// the receiver to distinguish PMTUD success from normal probe success without
+/// changing the ICMP identifier (which risks DGRAM/kernel filtering).
 pub fn build_echo_request(
     identifier: u16,
     sequence: u16,
     payload_size: usize,
     ipv6: bool,
     ipv6_addrs: Option<(Ipv6Addr, Ipv6Addr)>,
+    pmtud: bool,
 ) -> Vec<u8> {
     // Catch future callers who forget to pass addresses for IPv6
     debug_assert!(
@@ -117,8 +127,17 @@ pub fn build_echo_request(
         .as_micros() as u32;
     payload[4..8].copy_from_slice(&timestamp.to_be_bytes());
 
-    // Fill rest with pattern
+    // Byte 8: PMTUD marker (0x50='P' for PMTUD, 0x00 for normal)
+    // Normal probes set this to pattern index 0 (= 0x00) via the loop below.
+    if payload.len() > 8 && pmtud {
+        payload[8] = 0x50;
+    }
+
+    // Fill rest with pattern (byte 8 onwards; PMTUD marker already set above)
     for (i, byte) in payload[8..].iter_mut().enumerate() {
+        if pmtud && i == 0 {
+            continue; // Don't overwrite the marker
+        }
         *byte = (i & 0xFF) as u8;
     }
 
@@ -147,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_build_echo_request() {
-        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, false, None);
+        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, false, None, false);
         assert_eq!(packet.len(), ICMP_HEADER_SIZE + DEFAULT_PAYLOAD_SIZE);
         assert_eq!(packet[0], 8); // Echo Request type
         assert_eq!(packet[1], 0); // Code
@@ -158,7 +177,14 @@ mod tests {
         use std::str::FromStr;
         let src = Ipv6Addr::from_str("2001:db8::1").unwrap();
         let dest = Ipv6Addr::from_str("2001:db8::2").unwrap();
-        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, true, Some((src, dest)));
+        let packet = build_echo_request(
+            1234,
+            5678,
+            DEFAULT_PAYLOAD_SIZE,
+            true,
+            Some((src, dest)),
+            false,
+        );
         assert_eq!(packet.len(), ICMP_HEADER_SIZE + DEFAULT_PAYLOAD_SIZE);
         assert_eq!(packet[0], 128); // ICMPv6 Echo Request type
         assert_eq!(packet[1], 0); // Code
@@ -169,7 +195,14 @@ mod tests {
         use std::str::FromStr;
         let src = Ipv6Addr::from_str("2001:db8::1").unwrap();
         let dest = Ipv6Addr::from_str("2001:db8::2").unwrap();
-        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, true, Some((src, dest)));
+        let packet = build_echo_request(
+            1234,
+            5678,
+            DEFAULT_PAYLOAD_SIZE,
+            true,
+            Some((src, dest)),
+            false,
+        );
         assert_eq!(packet.len(), ICMP_HEADER_SIZE + DEFAULT_PAYLOAD_SIZE);
         assert_eq!(packet[0], 128); // ICMPv6 Echo Request type
         assert_eq!(packet[1], 0); // Code
@@ -194,11 +227,40 @@ mod tests {
     #[test]
     fn test_build_echo_request_custom_size() {
         // Test larger payload
-        let packet = build_echo_request(1234, 5678, 1400, false, None);
+        let packet = build_echo_request(1234, 5678, 1400, false, None, false);
         assert_eq!(packet.len(), ICMP_HEADER_SIZE + 1400);
 
         // Test minimum payload
-        let packet = build_echo_request(1234, 5678, 0, false, None);
+        let packet = build_echo_request(1234, 5678, 0, false, None, false);
         assert_eq!(packet.len(), ICMP_HEADER_SIZE + MIN_PAYLOAD_SIZE);
+    }
+
+    #[test]
+    fn test_pmtud_marker_set_in_payload() {
+        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, false, None, true);
+        // Payload starts at byte 8 (ICMP header size)
+        // PMTUD marker should be at payload byte 8 = packet byte 16
+        assert_eq!(
+            packet[16], PMTUD_MARKER,
+            "PMTUD marker should be set at payload[8]"
+        );
+    }
+
+    #[test]
+    fn test_normal_probe_has_no_pmtud_marker() {
+        let packet = build_echo_request(1234, 5678, DEFAULT_PAYLOAD_SIZE, false, None, false);
+        // Normal probe: payload[8] should be 0x00 (pattern fill index 0)
+        assert_eq!(
+            packet[16], 0x00,
+            "Normal probe should not have PMTUD marker"
+        );
+    }
+
+    #[test]
+    fn test_pmtud_marker_with_min_payload() {
+        // MIN_PAYLOAD_SIZE is 8, so payload[8] doesn't exist; marker is skipped
+        let packet = build_echo_request(1234, 5678, 0, false, None, true);
+        assert_eq!(packet.len(), ICMP_HEADER_SIZE + MIN_PAYLOAD_SIZE);
+        // No panic, marker gracefully skipped when payload too small
     }
 }

--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -440,7 +440,7 @@ mod tests {
             .expect("create IP_HDRINCL raw socket (needs root)");
 
         // ICMP echo.
-        let icmp = build_echo_request(0x4242, 1, 16, false, None);
+        let icmp = build_echo_request(0x4242, 1, 16, false, None, false);
         let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 5, 0, false, &icmp);
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected ICMP IP_HDRINCL packet (ip_len/ip_off byte order?)");
@@ -465,7 +465,7 @@ mod tests {
             .expect("kernel rejected TCP IP_HDRINCL packet (ip_len/ip_off byte order?)");
 
         // Also exercise the Don't Fragment path used by PMTUD.
-        let icmp_df = build_echo_request(0x4242, 2, 64, false, None);
+        let icmp_df = build_echo_request(0x4242, 2, 64, false, None, false);
         let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 8, 0, true, &icmp_df);
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected DF IP_HDRINCL packet (ip_len/ip_off byte order?)");
@@ -496,7 +496,7 @@ mod tests {
             .expect("create raw ICMP recv socket (needs root)");
         recv.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
 
-        let icmp = build_echo_request(ident, 1, 16, false, None);
+        let icmp = build_echo_request(ident, 1, 16, false, None, false);
         let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, ttl, tos, false, &icmp);
         send_raw_ipv4(&send, &pkt, lo).expect("send IP_HDRINCL echo to loopback");
 

--- a/src/trace/engine.rs
+++ b/src/trace/engine.rs
@@ -334,6 +334,7 @@ impl ProbeEngine {
                             payload_size,
                             self.target.is_ipv6(),
                             ipv6_addrs,
+                            false,
                         );
 
                         // Set TTL before sending
@@ -852,7 +853,7 @@ impl ProbeEngine {
                             .unwrap_or(DEFAULT_PAYLOAD_SIZE);
 
                         let icmp =
-                            build_echo_request(self.identifier, probe_id.to_sequence(), payload_size, false, None);
+                            build_echo_request(self.identifier, probe_id.to_sequence(), payload_size, false, None, false);
                         let packet = build_ipv4_packet(src, dst, IPPROTO_ICMP, ttl, tos, false, &icmp);
 
                         let sent_at = Instant::now();
@@ -1212,6 +1213,7 @@ impl ProbeEngine {
             payload_size,
             self.target.is_ipv6(),
             ipv6_addrs,
+            true,
         );
 
         // Set TTL
@@ -1320,6 +1322,7 @@ impl ProbeEngine {
             payload_size,
             false,
             None,
+            true,
         );
         // Don't Fragment set in the IP header so routers return Frag Needed.
         let packet = build_ipv4_packet(src, dst, IPPROTO_ICMP, dest_ttl, tos, true, &icmp);

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -111,6 +111,7 @@ impl Receiver {
         probe_id: ProbeId,
         target: IpAddr,
         flow_hint: Option<u8>,
+        is_pmtud_response: bool,
     ) -> Option<PendingProbe> {
         if let Some(flow_id) = flow_hint {
             if let Some(probe) = pending.remove(&(probe_id, flow_id, target, false)) {
@@ -134,6 +135,12 @@ impl Receiver {
                     normal_flows.push(flow_id);
                 }
             }
+        }
+
+        // If this is a PMTUD-related response (Frag Needed / Packet Too Big),
+        // prefer the PMTUD entry to avoid consuming a normal probe's pending slot.
+        if is_pmtud_response && pmtud_flows.len() == 1 {
+            return pending.remove(&(probe_id, pmtud_flows[0], target, true));
         }
 
         if normal_flows.len() == 1 {
@@ -188,19 +195,27 @@ impl Receiver {
                             identifier,
                             is_dgram,
                         ) {
-                            // Derive flow hint from quoted source port.
-                            // If the port is out of range (e.g., NAT rewrite), keep it unknown
-                            // and only match pending probes when unambiguous.
                             let flow_hint = self.derive_flow_hint(parsed.src_port);
+
+                            // PMTUD responses are Frag Needed (DestUnreachable code 4)
+                            // or ICMPv6 Packet Too Big. Prefer PMTUD pending entry for these.
+                            let is_pmtud_response = matches!(
+                                parsed.response_type,
+                                IcmpResponseType::DestUnreachable(4)
+                                    | IcmpResponseType::PacketTooBig
+                            );
 
                             // Find matching pending probe (key includes flow_id, target, is_pmtud)
                             let mut found_probe = None;
                             {
-                                // Read live target list before taking the pending lock
-                                // (targets can be added mid-session in interactive mode;
-                                // sessions lock is never acquired while pending is held)
-                                let fallback_targets: Vec<IpAddr> =
-                                    self.sessions.read().keys().copied().collect();
+                                // Collect target list BEFORE acquiring the pending lock.
+                                // Lock order: sessions.read() is always acquired and released
+                                // before pending.write() to prevent deadlock.
+                                let fallback_targets: Vec<IpAddr> = {
+                                    let sessions = self.sessions.read();
+                                    sessions.keys().copied().collect()
+                                };
+                                // sessions guard dropped here
 
                                 let mut pending = self.pending.write();
 
@@ -211,6 +226,7 @@ impl Receiver {
                                         parsed.probe_id,
                                         dest,
                                         flow_hint,
+                                        is_pmtud_response,
                                     );
                                 }
 
@@ -222,6 +238,7 @@ impl Receiver {
                                             parsed.probe_id,
                                             *target,
                                             flow_hint,
+                                            is_pmtud_response,
                                         ) {
                                             found_probe = Some(probe);
                                             break;
@@ -578,7 +595,8 @@ mod tests {
             },
         );
 
-        let removed = Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None);
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, false);
         assert!(removed.is_some(), "single candidate should be removable");
         assert!(pending.is_empty());
     }
@@ -601,7 +619,8 @@ mod tests {
             );
         }
 
-        let removed = Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None);
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, false);
         assert!(
             removed.is_none(),
             "ambiguous candidates should not be forced"
@@ -635,7 +654,8 @@ mod tests {
             },
         );
 
-        let removed = Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None);
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, false);
         assert!(removed.is_some());
         let removed = removed.unwrap();
         assert_eq!(removed.flow_id, 1);
@@ -671,7 +691,8 @@ mod tests {
             },
         );
 
-        let removed = Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None);
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, false);
         assert!(removed.is_none());
         assert_eq!(pending.len(), 3);
     }

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -114,11 +114,20 @@ impl Receiver {
         is_pmtud_response: bool,
     ) -> Option<PendingProbe> {
         if let Some(flow_id) = flow_hint {
-            if let Some(probe) = pending.remove(&(probe_id, flow_id, target, false)) {
-                return Some(probe);
-            }
-            if let Some(probe) = pending.remove(&(probe_id, flow_id, target, true)) {
-                return Some(probe);
+            if is_pmtud_response {
+                if let Some(probe) = pending.remove(&(probe_id, flow_id, target, true)) {
+                    return Some(probe);
+                }
+                if let Some(probe) = pending.remove(&(probe_id, flow_id, target, false)) {
+                    return Some(probe);
+                }
+            } else {
+                if let Some(probe) = pending.remove(&(probe_id, flow_id, target, false)) {
+                    return Some(probe);
+                }
+                if let Some(probe) = pending.remove(&(probe_id, flow_id, target, true)) {
+                    return Some(probe);
+                }
             }
             return None;
         }
@@ -695,5 +704,40 @@ mod tests {
             Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, false);
         assert!(removed.is_none());
         assert_eq!(pending.len(), 3);
+    }
+
+    #[test]
+    fn test_remove_pending_explicit_flow_pmtud_response_prefers_pmtud() {
+        let probe_id = ProbeId::new(4, 11);
+        let target = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 4, 4));
+        let mut pending: HashMap<(ProbeId, u8, IpAddr, bool), PendingProbe> = HashMap::new();
+
+        pending.insert(
+            (probe_id, 0, target, false),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 0,
+                original_src_port: None,
+                packet_size: None,
+            },
+        );
+        pending.insert(
+            (probe_id, 0, target, true),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 0,
+                original_src_port: None,
+                packet_size: Some(1400),
+            },
+        );
+
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, Some(0), true);
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().packet_size, Some(1400));
+        assert!(pending.contains_key(&(probe_id, 0, target, false)));
+        assert!(!pending.contains_key(&(probe_id, 0, target, true)));
     }
 }

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -206,13 +206,16 @@ impl Receiver {
                         ) {
                             let flow_hint = self.derive_flow_hint(parsed.src_port);
 
-                            // PMTUD responses are Frag Needed (DestUnreachable code 4)
-                            // or ICMPv6 Packet Too Big. Prefer PMTUD pending entry for these.
-                            let is_pmtud_response = matches!(
-                                parsed.response_type,
-                                IcmpResponseType::DestUnreachable(4)
-                                    | IcmpResponseType::PacketTooBig
-                            );
+                            // Determine if this response is for a PMTUD probe.
+                            // For Echo Reply: detected via PMTUD payload marker (parsed.is_pmtud).
+                            // For Frag Needed / Packet Too Big: these are always PMTUD responses
+                            // (only PMTUD probes set DF), so also route to PMTUD pending entry.
+                            let is_pmtud_response = parsed.is_pmtud
+                                || matches!(
+                                    parsed.response_type,
+                                    IcmpResponseType::DestUnreachable(4)
+                                        | IcmpResponseType::PacketTooBig
+                                );
 
                             // Find matching pending probe (key includes flow_id, target, is_pmtud)
                             let mut found_probe = None;
@@ -751,5 +754,87 @@ mod tests {
         assert_eq!(removed.unwrap().packet_size, Some(1400));
         assert!(pending.contains_key(&(probe_id, 0, target, false)));
         assert!(!pending.contains_key(&(probe_id, 0, target, true)));
+    }
+
+    #[test]
+    fn test_remove_pending_unknown_flow_pmtud_echo_reply_prefers_pmtud_entry() {
+        // Simulates the critical PMTUD success case: a PMTUD probe reaches the
+        // destination and gets an Echo Reply. Both normal and PMTUD pending entries
+        // share the same (probe_id, target) but differ in is_pmtud flag.
+        // Without the PMTUD marker, the receiver would consume the normal entry
+        // and leave the PMTUD probe to time out.
+        let probe_id = ProbeId::new(5, 3);
+        let target = IpAddr::V4(std::net::Ipv4Addr::new(1, 2, 3, 4));
+        let mut pending: HashMap<(ProbeId, u8, IpAddr, bool), PendingProbe> = HashMap::new();
+        pending.insert(
+            (probe_id, 0, target, false),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 0,
+                original_src_port: None,
+                packet_size: None,
+            },
+        );
+        pending.insert(
+            (probe_id, 0, target, true),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 0,
+                original_src_port: None,
+                packet_size: Some(1200),
+            },
+        );
+
+        // Echo Reply from PMTUD probe: is_pmtud_response=true via payload marker
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, Some(0), true);
+        assert!(removed.is_some(), "should remove PMTUD entry");
+        assert_eq!(removed.unwrap().packet_size, Some(1200));
+        // Normal entry should remain
+        assert!(pending.contains_key(&(probe_id, 0, target, false)));
+        assert!(!pending.contains_key(&(probe_id, 0, target, true)));
+    }
+
+    #[test]
+    fn test_remove_pending_unknown_flow_pmtud_echo_reply_no_flow_hint() {
+        // Same as above but with unknown flow hint (NAT rewrote the port).
+        // Each entry has a unique flow, so the PMTUD one should be preferred.
+        let probe_id = ProbeId::new(5, 4);
+        let target = IpAddr::V4(std::net::Ipv4Addr::new(5, 6, 7, 8));
+        let mut pending: HashMap<(ProbeId, u8, IpAddr, bool), PendingProbe> = HashMap::new();
+        pending.insert(
+            (probe_id, 1, target, false),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 1,
+                original_src_port: Some(50001),
+                packet_size: None,
+            },
+        );
+        pending.insert(
+            (probe_id, 2, target, true),
+            PendingProbe {
+                sent_at: Instant::now(),
+                target,
+                flow_id: 2,
+                original_src_port: Some(50002),
+                packet_size: Some(1300),
+            },
+        );
+
+        // PMTUD Echo Reply with unknown flow: should prefer PMTUD entry
+        let removed =
+            Receiver::remove_pending_by_flow_hint(&mut pending, probe_id, target, None, true);
+        assert!(
+            removed.is_some(),
+            "should remove PMTUD entry for Echo Reply"
+        );
+        assert_eq!(removed.unwrap().packet_size, Some(1300));
+        // Normal entry should remain
+        assert!(pending.contains_key(&(probe_id, 1, target, false)));
+        assert!(!pending.contains_key(&(probe_id, 2, target, true)));
     }
 }

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -13,7 +13,7 @@ use crate::probe::{
 use crate::state::{
     IcmpResponseType, MplsLabel, PmtudPhase, ProbeEvent, ProbeId, ProbeOutcome, Session,
 };
-use crate::trace::pending::{PendingMap, PendingProbe};
+use crate::trace::pending::{PendingKey, PendingMap, PendingProbe};
 
 /// Map of target IP to session, shared across multiple engines and the receiver
 pub type SessionMap = Arc<RwLock<HashMap<IpAddr, Arc<RwLock<Session>>>>>;
@@ -217,9 +217,8 @@ impl Receiver {
                             // Find matching pending probe (key includes flow_id, target, is_pmtud)
                             let mut found_probe = None;
                             {
-                                // Collect target list BEFORE acquiring the pending lock.
-                                // Lock order: sessions.read() is always acquired and released
-                                // before pending.write() to prevent deadlock.
+                                // Collect target list before acquiring pending. Avoid holding
+                                // sessions and pending locks at the same time.
                                 let fallback_targets: Vec<IpAddr> = {
                                     let sessions = self.sessions.read();
                                     sessions.keys().copied().collect()
@@ -453,73 +452,86 @@ impl Receiver {
             // This runs after draining the socket, so queued responses aren't lost
             {
                 let now = Instant::now();
-                let mut pending = self.pending.write();
-                let sessions = self.sessions.read();
                 let timeout = self.config.timeout;
-                // Key is (ProbeId, flow_id, target, is_pmtud) tuple
-                pending.retain(|(probe_id, _flow_id, target, _is_pmtud), probe| {
-                    if now.duration_since(probe.sent_at) > timeout {
-                        let is_pmtud_probe = probe.packet_size.is_some();
 
-                        if let Some(session) = sessions.get(target) {
-                            let mut state = session.write();
+                let timed_out = {
+                    let mut pending = self.pending.write();
+                    let mut timed_out = Vec::new();
 
-                            // Only record hop timeouts for normal probes, not PMTUD probes
-                            if !is_pmtud_probe {
-                                if let Some(hop) = state.hop_mut(probe_id.ttl) {
-                                    hop.record_timeout();
-                                    hop.record_flow_timeout(probe.flow_id);
-                                }
-
-                                // Record event for animated replay (monotonic timing)
-                                let offset_ms = state.offset_ms();
-                                state.record_event(ProbeEvent {
-                                    offset_ms,
-                                    ttl: probe_id.ttl,
-                                    seq: probe_id.seq,
-                                    flow_id: probe.flow_id,
-                                    outcome: ProbeOutcome::Timeout,
-                                });
-                            }
-
-                            // PMTUD: Record failure for timed out PMTUD probes
-                            // Verify packet_size matches current_size to ignore late timeouts from old sizes
-                            if let Some(probe_size) = probe.packet_size
-                                && let Some(ref mut pmtud) = state.pmtud
-                                && pmtud.phase == PmtudPhase::Searching
-                                && probe_size == pmtud.current_size
-                            {
-                                pmtud.record_failure();
-                            }
+                    // Key is (ProbeId, flow_id, target, is_pmtud) tuple
+                    pending.retain(|key, probe| {
+                        if now.duration_since(probe.sent_at) > timeout {
+                            timed_out.push((*key, probe.clone()));
+                            false
+                        } else {
+                            true
                         }
-                        false
-                    } else {
-                        true
-                    }
-                });
+                    });
+
+                    timed_out
+                };
+
+                self.record_pending_timeouts(timed_out, true, true);
             }
         }
 
         Ok(())
     }
 
-    /// Flush all remaining pending probes as timeouts on shutdown.
-    fn flush_pending_as_timeouts(&self) {
-        let mut pending = self.pending.write();
-        let sessions = self.sessions.read();
+    /// Record timeout effects after pending probes have been removed.
+    fn record_pending_timeouts(
+        &self,
+        timed_out: Vec<(PendingKey, PendingProbe)>,
+        record_events: bool,
+        update_pmtud: bool,
+    ) {
+        if timed_out.is_empty() {
+            return;
+        }
 
-        // Drain all remaining probes and record them as timeouts
-        for ((probe_id, _flow_id, target, is_pmtud), probe) in pending.drain() {
+        let sessions = self.sessions.read();
+        for ((probe_id, _flow_id, target, is_pmtud), probe) in timed_out {
             if let Some(session) = sessions.get(&target) {
                 let mut state = session.write();
 
                 // Only record hop timeouts for normal probes, not PMTUD probes
-                if !is_pmtud && let Some(hop) = state.hop_mut(probe_id.ttl) {
-                    hop.record_timeout();
-                    hop.record_flow_timeout(probe.flow_id);
+                if !is_pmtud {
+                    if let Some(hop) = state.hop_mut(probe_id.ttl) {
+                        hop.record_timeout();
+                        hop.record_flow_timeout(probe.flow_id);
+                    }
+
+                    if record_events {
+                        // Record event for animated replay (monotonic timing)
+                        let offset_ms = state.offset_ms();
+                        state.record_event(ProbeEvent {
+                            offset_ms,
+                            ttl: probe_id.ttl,
+                            seq: probe_id.seq,
+                            flow_id: probe.flow_id,
+                            outcome: ProbeOutcome::Timeout,
+                        });
+                    }
+                }
+
+                // PMTUD: Record failure for timed out PMTUD probes. Verify packet_size
+                // matches current_size to ignore late timeouts from old sizes.
+                if update_pmtud
+                    && let Some(probe_size) = probe.packet_size
+                    && let Some(ref mut pmtud) = state.pmtud
+                    && pmtud.phase == PmtudPhase::Searching
+                    && probe_size == pmtud.current_size
+                {
+                    pmtud.record_failure();
                 }
             }
         }
+    }
+
+    /// Flush all remaining pending probes as timeouts on shutdown.
+    fn flush_pending_as_timeouts(&self) {
+        let timed_out: Vec<_> = self.pending.write().drain().collect();
+        self.record_pending_timeouts(timed_out, false, false);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes PMTUD probe correlation correctness, documents lock ordering, and deduplicates enrichment lookup targets.

## Changes

### #3 (high): PMTUD Echo Reply correlation via on-wire payload marker

PMTUD probes and normal probes share the same ICMP identifier and `ProbeId` sequence space. When both a normal and PMTUD pending entry existed for the same `(ProbeId, target)`, the receiver couldn't distinguish which type of probe an Echo Reply was for. It preferred the normal entry, causing the PMTUD probe to time out and `record_failure()` to be called — leading to MTU under-estimation.

**Fix:** Write a PMTUD marker byte (`0x50`) at payload byte 8 of ICMP Echo Requests. Echo Replies echo the payload verbatim, so the receiver detects PMTUD success via `parsed.is_pmtud`. For Frag Needed / Packet Too Big responses (which quote the original packet, possibly truncated to 8 bytes per RFC 792), the response type is used as a fallback discriminator: `is_pmtud_response = parsed.is_pmtud || matches!(response_type, DestUnreachable(4) | PacketTooBig)`.

- `build_echo_request` gains a `pmtud: bool` parameter; when true, payload byte 8 is set to `PMTUD_MARKER` (0x50) instead of the normal pattern fill (0x00)
- `ParsedResponse` gains an `is_pmtud: bool` field, set by checking the marker in Echo Reply payload via `is_pmtud_payload()`
- `remove_pending_by_flow_hint` routes to the PMTUD pending entry when `is_pmtud_response` is true

### #10 (medium): Lock ordering documentation

Explicitly scopes the `sessions.read()` guard in a nested block so it is dropped before `pending.write()` is acquired in the receiver drain loop. Documents the lock order (`sessions` before `pending`, never nested) to prevent future deadlock regressions.

### #12 (medium): Enrichment IP deduplication

Deduplicates IPs via `HashSet` before `take(MAX_CONCURRENT_LOOKUPS)` in all four enrichment workers (ASN, rDNS, GeoIP, IX). Previously, duplicate responder IPs across targets could occupy multiple concurrent lookup slots, wasting resources on redundant lookups.

## Testing

- 511 tests pass (18 new); `cargo clippy --all-targets -- -D warnings` clean.
- New tests include:
  - `test_pmtud_marker_set_in_payload` / `test_normal_probe_has_no_pmtud_marker` — builder tests
  - `test_parse_pmtud_echo_reply_v4_dgram` / `test_parse_normal_echo_reply_v4_dgram` / `test_parse_pmtud_echo_reply_v4_raw` — end-to-end parse tests that build a real Echo Request via `build_echo_request`, convert to Echo Reply, and verify `parsed.is_pmtud`
  - `test_remove_pending_unknown_flow_pmtud_echo_reply_prefers_pmtud_entry` / `test_remove_pending_unknown_flow_pmtud_echo_reply_no_flow_hint` — pending removal routing tests
  - `test_remove_pending_explicit_flow_pmtud_response_prefers_pmtud` — existing test updated for new signature

## Risk

Medium — the PMTUD correlation change touches the receiver's probe-matching logic and adds a new on-wire byte (payload[8]). Normal probes set this to 0x00 (pattern fill), so there's no wire-protocol conflict. The marker is only checked for Echo Replies, not error responses (which may truncate the quoted payload).
