### PR TITLE
docs: add SAFETY comment to set_ip_hdrincl unsafe block

### DIFF
--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -230,6 +230,14 @@ pub fn create_raw_hdrincl_socket_with_interface(
 fn set_ip_hdrincl(socket: &Socket) -> Result<()> {
     use std::os::unix::io::AsRawFd;
     let one: libc::c_int = 1;
+    // SAFETY: `socket.as_raw_fd()` yields a valid open file descriptor for the
+    // lifetime of the borrow (the `Socket` outlives this call). `IPPROTO_IP` and
+    // `IP_HDRINCL` are compile-time constants. `one` is a stack `c_int` that lives
+    // until after the call returns, so the `*const c_void` pointer and the
+    // `size_of_val(&one)` length denote a valid, initialized `c_int` for the
+    // duration of `setsockopt`. `setsockopt` itself is thread-safe and performs no
+    // synchronization that could deadlock. The only error mode is a negative
+    // return, which we translate below via `last_os_error()`.
     let ret = unsafe {
         libc::setsockopt(
             socket.as_raw_fd(),


### PR DESCRIPTION
## Summary

Adds a `SAFETY` justification comment to the `unsafe` block in `set_ip_hdrincl` (`src/probe/rawip.rs`) that calls `libc::setsockopt`.

The `unsafe` block previously had no `// SAFETY:` comment explaining why the call is safe, flagged by the weekly review (LAN-179).

## Changes

- Add `// SAFETY:` comment documenting why the raw fd, option constants, stack `c_int` pointer, and length are valid for the duration of the `setsockopt` call.

## Testing

- `cargo clippy --lib --bin ttl -- -D warnings` clean
- `cargo test` passes (full suite via pre-push hook)

Closes LAN-179.