### PR TITLE
fix: propagate IPv6 scope_id through recv/bind paths (LAN-143)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,9 +203,13 @@ pub struct Args {
     #[arg(long = "rate", value_parser = clap::value_parser!(u32).range(0..=10000))]
     pub rate: Option<u32>,
 
-    /// Source IP address for probes
+    /// Source IP address for probes (supports IPv6 zone: fe80::1%eth0)
     #[arg(long = "source-ip", value_name = "IP")]
-    pub source_ip: Option<std::net::IpAddr>,
+    pub source_ip: Option<String>,
+
+    /// Parsed IPv6 scope ID from `--source-ip` zone (populated in `validate`)
+    #[arg(skip)]
+    pub source_ip_scope_id: Option<u32>,
 
     /// Generate shell completions and exit
     #[arg(long, value_name = "SHELL", value_parser = ["bash", "zsh", "fish", "powershell"])]
@@ -258,7 +262,7 @@ impl Args {
     }
 
     /// Validate arguments
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&mut self) -> Result<(), String> {
         // Interactive TUI mode supports starting empty (add targets with 'o');
         // every other mode needs at least one target up front
         if self.targets.is_empty() && (self.is_batch_mode() || self.is_headless()) {
@@ -383,6 +387,46 @@ impl Args {
             }
         }
 
+        // Parse --source-ip zone ID (e.g. fe80::1%eth0 → scope_id)
+        if let Some(raw) = &self.source_ip {
+            let (ip_part, zone) = match raw.split_once('%') {
+                Some((ip, zone)) => (ip, Some(zone)),
+                None => (raw.as_str(), None),
+            };
+            // Validate the IP part parses
+            if ip_part.parse::<std::net::IpAddr>().is_err() {
+                return Err(format!("Invalid source IP: {raw}"));
+            }
+            // Resolve zone to numeric scope_id
+            if let Some(zone) = zone {
+                // Numeric scope_id (e.g. "2")
+                match zone.parse::<u32>() {
+                    Ok(id) => self.source_ip_scope_id = Some(id),
+                    Err(_) => {
+                        // Interface name (e.g. "eth0") → resolve via if_nametoindex
+                        #[cfg(unix)]
+                        {
+                            let cname = std::ffi::CString::new(zone)
+                                .map_err(|_| format!("Invalid zone name: {zone}"))?;
+                            let idx = unsafe { libc::if_nametoindex(cname.as_ptr()) };
+                            if idx == 0 {
+                                return Err(format!(
+                                    "Unknown interface '{zone}' in --source-ip zone"
+                                ));
+                            }
+                            self.source_ip_scope_id = Some(idx);
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            return Err(format!(
+                                "Interface name zone '{zone}' not supported on this platform; \
+                                 use a numeric scope ID"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -432,6 +476,7 @@ mod tests {
             jumbo: false,
             rate: None,
             source_ip: None,
+            source_ip_scope_id: None,
             completions: None,
         };
         overrides(&mut args);
@@ -441,7 +486,7 @@ mod tests {
     #[test]
     fn test_src_port_flows_valid_at_max() {
         // src_port=65520, flows=16 uses ports 65520..65535 (valid)
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.src_port = 65520;
             a.flows = 16;
         });
@@ -451,7 +496,7 @@ mod tests {
     #[test]
     fn test_src_port_flows_overflow() {
         // src_port=65521, flows=16 would use port 65536 (invalid)
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.src_port = 65521;
             a.flows = 16;
         });
@@ -461,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_nan_interval_rejected() {
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.interval = f64::NAN;
         });
         assert!(args.validate().unwrap_err().contains("positive, finite"));
@@ -469,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_inf_timeout_rejected() {
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = f64::INFINITY;
         });
         assert!(args.validate().unwrap_err().contains("positive, finite"));
@@ -477,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_huge_interval_rejected() {
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.interval = 1e300;
         });
         assert!(args.validate().unwrap_err().contains("too large"));
@@ -485,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_huge_timeout_rejected() {
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = 1e300;
         });
         assert!(args.validate().unwrap_err().contains("too large"));
@@ -494,7 +539,7 @@ mod tests {
     #[test]
     fn test_port_max_ttl_overflow_rejected() {
         // port=65530, max_ttl=30 → max port 65560 (overflows u16) unless --fixed-port
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.protocol = "udp".to_string();
             a.port = Some(65530);
             a.max_ttl = 30;
@@ -505,7 +550,7 @@ mod tests {
     #[test]
     fn test_port_max_ttl_valid_at_boundary() {
         // port=65505, max_ttl=30 → max port 65535 (valid)
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.protocol = "udp".to_string();
             a.port = Some(65505);
             a.max_ttl = 30;
@@ -523,7 +568,7 @@ mod tests {
     #[test]
     fn test_port_max_ttl_fixed_port_skips_check() {
         // With --fixed-port, the per-TTL port variation is disabled
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.protocol = "udp".to_string();
             a.port = Some(65530);
             a.max_ttl = 30;
@@ -535,7 +580,7 @@ mod tests {
     #[test]
     fn test_timeout_interval_valid() {
         // timeout=255s with interval=1s is just under the limit (must be < 256 × interval)
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = 255.0;
             a.interval = 1.0;
         });
@@ -545,7 +590,7 @@ mod tests {
     #[test]
     fn test_timeout_interval_boundary_rejected() {
         // timeout=256s with interval=1s is exactly at the limit — now rejected
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = 256.0;
             a.interval = 1.0;
         });
@@ -555,7 +600,7 @@ mod tests {
     #[test]
     fn test_timeout_interval_wrap_rejected() {
         // timeout=257s with interval=1s exceeds 256 × interval
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = 257.0;
             a.interval = 1.0;
         });
@@ -566,7 +611,7 @@ mod tests {
     #[test]
     fn test_timeout_interval_fast_probes() {
         // With 0.1s interval, timeout must be <= 25.6s
-        let args = make_args(|a| {
+        let mut args = make_args(|a| {
             a.timeout = 30.0;
             a.interval = 0.1;
         });
@@ -609,38 +654,38 @@ mod tests {
 
     #[test]
     fn test_empty_targets_interactive_ok() {
-        let args = make_args(|a| a.targets = vec![]);
+        let mut args = make_args(|a| a.targets = vec![]);
         assert!(args.validate().is_ok());
     }
 
     #[test]
     fn test_empty_targets_rejected_for_non_interactive_modes() {
-        let no_tui = make_args(|a| {
+        let mut no_tui = make_args(|a| {
             a.targets = vec![];
             a.no_tui = true;
         });
         assert!(no_tui.validate().unwrap_err().contains("No targets"));
 
-        let batch = make_args(|a| {
+        let mut batch = make_args(|a| {
             a.targets = vec![];
             a.json = true;
             a.count = 5;
         });
         assert!(batch.validate().is_err());
 
-        let daemon = make_args(|a| {
+        let mut daemon = make_args(|a| {
             a.targets = vec![];
             a.daemon = true;
         });
         assert!(daemon.validate().is_err());
 
-        let stream = make_args(|a| {
+        let mut stream = make_args(|a| {
             a.targets = vec![];
             a.stream_json = true;
         });
         assert!(stream.validate().is_err());
 
-        let prom = make_args(|a| {
+        let mut prom = make_args(|a| {
             a.targets = vec![];
             a.prometheus = Some(":9090".to_string());
         });
@@ -649,7 +694,7 @@ mod tests {
 
     #[test]
     fn test_prometheus_addr_shorthand() {
-        let args = make_args(|a| a.prometheus = Some(":9090".to_string()));
+        let mut args = make_args(|a| a.prometheus = Some(":9090".to_string()));
         assert_eq!(
             args.prometheus_addr(),
             Some("0.0.0.0:9090".parse().unwrap())
@@ -669,9 +714,52 @@ mod tests {
 
     #[test]
     fn test_prometheus_addr_invalid() {
-        let args = make_args(|a| a.prometheus = Some("not-an-addr".to_string()));
+        let mut args = make_args(|a| a.prometheus = Some("not-an-addr".to_string()));
         assert!(args.prometheus_addr().is_none());
         assert!(args.validate().unwrap_err().contains("--prometheus"));
+    }
+
+    #[test]
+    fn test_source_ip_plain_ipv4() {
+        let mut args = make_args(|a| a.source_ip = Some("192.168.1.1".to_string()));
+        assert!(args.validate().is_ok());
+        assert_eq!(args.source_ip_scope_id, None);
+    }
+
+    #[test]
+    fn test_source_ip_plain_ipv6() {
+        let mut args = make_args(|a| {
+            a.source_ip = Some("2001:db8::1".to_string());
+            a.ipv6 = true;
+        });
+        assert!(args.validate().is_ok());
+        assert_eq!(args.source_ip_scope_id, None);
+    }
+
+    #[test]
+    fn test_source_ip_ipv6_numeric_scope() {
+        let mut args = make_args(|a| {
+            a.source_ip = Some("fe80::1%5".to_string());
+            a.ipv6 = true;
+        });
+        assert!(args.validate().is_ok());
+        assert_eq!(args.source_ip_scope_id, Some(5));
+    }
+
+    #[test]
+    fn test_source_ip_invalid_ip() {
+        let mut args = make_args(|a| a.source_ip = Some("not-an-ip".to_string()));
+        assert!(args.validate().unwrap_err().contains("Invalid source IP"));
+    }
+
+    #[test]
+    fn test_source_ip_invalid_zone_interface() {
+        let mut args = make_args(|a| {
+            a.source_ip = Some("fe80::1%nonexistent99".to_string());
+            a.ipv6 = true;
+        });
+        let err = args.validate().unwrap_err();
+        assert!(err.contains("Unknown interface"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,9 @@ pub struct Config {
     /// Source IP address for probes
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_ip: Option<IpAddr>,
+    /// IPv6 scope ID for link-local source IP (zone index from `--source-ip fe80::%eth0`)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ip_scope_id: Option<u32>,
 }
 
 fn default_flows() -> u8 {
@@ -101,9 +104,10 @@ impl Default for Config {
             dscp: None,
             packet_size: None,
             pmtud: false,
+            source_ip: None,
+            source_ip_scope_id: None,
             jumbo: false,
             rate: None,
-            source_ip: None,
         }
     }
 }
@@ -149,7 +153,12 @@ impl From<&Args> for Config {
             pmtud: args.pmtud,
             jumbo: args.jumbo,
             rate: args.rate,
-            source_ip: args.source_ip,
+            source_ip: args.source_ip.as_deref().and_then(|s| {
+                // Strip zone ID for the IpAddr; scope_id is stored separately.
+                let ip_str = s.split('%').next().unwrap_or(s);
+                ip_str.parse().ok()
+            }),
+            source_ip_scope_id: args.source_ip_scope_id,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use tui::views::target_input::{AddTargetRequest, AddedTarget};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let mut args = Args::parse();
 
     // Handle shell completion generation (instant, no update check needed)
     if let Some(ref shell) = args.completions {

--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -224,7 +224,7 @@ pub fn create_raw_hdrincl_socket_with_interface(
 
     // Bind to the configured source IP so a non-local --source-ip fails fast.
     if let Some(src) = bind_src {
-        bind_to_source_ip(&socket, IpAddr::V4(src))?;
+        bind_to_source_ip(&socket, IpAddr::V4(src), None)?;
     }
 
     Ok(socket)

--- a/src/probe/socket.rs
+++ b/src/probe/socket.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::time::Duration;
 
 /// Socket capability level
@@ -275,10 +275,16 @@ pub fn set_dscp(socket: &Socket, dscp: u8, ipv6: bool) -> Result<()> {
     Ok(())
 }
 
-/// Bind socket to a specific source IP address
-/// Call this after interface binding (if any) to force a specific source address
-pub fn bind_to_source_ip(socket: &Socket, ip: IpAddr) -> Result<()> {
-    let addr = SocketAddr::new(ip, 0);
+/// Bind socket to a specific source IP address.
+///
+/// Call this after interface binding (if any) to force a specific source address.
+/// For IPv6 link-local addresses, `scope_id` identifies the interface and must be
+/// provided for the bind to succeed (LAN-143).
+pub fn bind_to_source_ip(socket: &Socket, ip: IpAddr, scope_id: Option<u32>) -> Result<()> {
+    let addr = match (ip, scope_id) {
+        (IpAddr::V6(v6), Some(scope)) => SocketAddr::V6(SocketAddrV6::new(v6, 0, 0, scope)),
+        (ip, _) => SocketAddr::new(ip, 0),
+    };
     socket.bind(&SockAddr::from(addr))?;
     Ok(())
 }
@@ -424,6 +430,8 @@ pub fn send_icmp(socket: &Socket, packet: &[u8], target: IpAddr) -> Result<usize
 pub struct RecvResult {
     pub len: usize,
     pub source: IpAddr,
+    /// IPv6 scope ID from the source address (non-zero for link-local responders)
+    pub scope_id: Option<u32>,
     /// TTL/hop-limit from the IP header of the response packet
     pub response_ttl: Option<u8>,
 }
@@ -513,8 +521,8 @@ pub fn recv_icmp_with_ttl(socket: &Socket, buffer: &mut [u8], ipv6: bool) -> Res
         return Err(std::io::Error::last_os_error().into());
     }
 
-    // Parse source address
-    let source = parse_sockaddr_storage(&src_storage)?;
+    // Parse source address (and IPv6 scope ID for link-local responders)
+    let (source, scope_id) = parse_sockaddr_storage(&src_storage)?;
 
     // Check for MSG_CTRUNC - control message truncated, TTL may be unreliable
     let response_ttl = if msg.msg_flags & libc::MSG_CTRUNC != 0 {
@@ -527,6 +535,7 @@ pub fn recv_icmp_with_ttl(socket: &Socket, buffer: &mut [u8], ipv6: bool) -> Res
     Ok(RecvResult {
         len: len as usize,
         source,
+        scope_id,
         response_ttl,
     })
 }
@@ -601,19 +610,30 @@ fn extract_ttl_from_cmsg(msg: &libc::msghdr, ipv6: bool) -> Option<u8> {
     None
 }
 
-/// Parse sockaddr_storage to IpAddr
+/// Parse sockaddr_storage to IpAddr and (for IPv6) the scope ID.
+///
+/// For link-local IPv6 responders, `sin6_scope_id` identifies the interface the
+/// response arrived on. Dropping it makes the address ambiguous when multiple
+/// interfaces have link-local routers (LAN-143).
 #[cfg(unix)]
-fn parse_sockaddr_storage(storage: &libc::sockaddr_storage) -> Result<IpAddr> {
+fn parse_sockaddr_storage(storage: &libc::sockaddr_storage) -> Result<(IpAddr, Option<u32>)> {
     match storage.ss_family as libc::c_int {
         libc::AF_INET => {
             let addr: &libc::sockaddr_in = unsafe { &*(storage as *const _ as *const _) };
             let ip = std::net::Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr));
-            Ok(IpAddr::V4(ip))
+            Ok((IpAddr::V4(ip), None))
         }
         libc::AF_INET6 => {
             let addr: &libc::sockaddr_in6 = unsafe { &*(storage as *const _ as *const _) };
             let ip = std::net::Ipv6Addr::from(addr.sin6_addr.s6_addr);
-            Ok(IpAddr::V6(ip))
+            // sin6_scope_id is 0 for non-link-local addresses; preserve it so
+            // link-local responders can be disambiguated.
+            let scope_id = if addr.sin6_scope_id != 0 {
+                Some(addr.sin6_scope_id)
+            } else {
+                None
+            };
+            Ok((IpAddr::V6(ip), scope_id))
         }
         _ => Err(anyhow!("Unknown address family: {}", storage.ss_family)),
     }
@@ -662,6 +682,8 @@ pub fn create_recv_socket_with_interface(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn test_probe_id_encoding() {
         use crate::state::ProbeId;
@@ -672,5 +694,59 @@ mod tests {
 
         assert_eq!(decoded.ttl, 15);
         assert_eq!(decoded.seq, 42);
+    }
+
+    #[test]
+    fn test_parse_sockaddr_storage_ipv6_scope_id() {
+        use std::mem;
+
+        // Build a sockaddr_in6 with a link-local address and scope_id=3
+        let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
+        let sin6: &mut libc::sockaddr_in6 =
+            unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_in6) };
+        sin6.sin6_family = libc::AF_INET6 as _;
+        sin6.sin6_addr.s6_addr = [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+        sin6.sin6_scope_id = 3;
+
+        let (ip, scope_id) = parse_sockaddr_storage(&storage).unwrap();
+        assert!(ip.is_ipv6());
+        assert_eq!(scope_id, Some(3));
+    }
+
+    #[test]
+    fn test_parse_sockaddr_storage_ipv6_no_scope_id() {
+        use std::mem;
+
+        // Global IPv6 address — scope_id should be None (sin6_scope_id == 0)
+        let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
+        let sin6: &mut libc::sockaddr_in6 =
+            unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_in6) };
+        sin6.sin6_family = libc::AF_INET6 as _;
+        sin6.sin6_addr.s6_addr = [
+            0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88,
+        ];
+        sin6.sin6_scope_id = 0;
+
+        let (ip, scope_id) = parse_sockaddr_storage(&storage).unwrap();
+        assert!(ip.is_ipv6());
+        assert_eq!(scope_id, None);
+    }
+
+    #[test]
+    fn test_parse_sockaddr_storage_ipv4() {
+        use std::mem;
+
+        let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
+        let sin: &mut libc::sockaddr_in =
+            unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_in) };
+        sin.sin_family = libc::AF_INET as _;
+        sin.sin_addr.s_addr = u32::from_be_bytes([8, 8, 8, 8]).to_be();
+
+        let (ip, scope_id) = parse_sockaddr_storage(&storage).unwrap();
+        assert_eq!(
+            ip,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8))
+        );
+        assert_eq!(scope_id, None);
     }
 }

--- a/src/probe/udp.rs
+++ b/src/probe/udp.rs
@@ -97,7 +97,7 @@ pub fn create_udp_dgram_socket_bound_with_interface(
     src_port: u16,
     interface: Option<&InterfaceInfo>,
 ) -> Result<Socket> {
-    create_udp_dgram_socket_bound_full(ipv6, src_port, interface, None)
+    create_udp_dgram_socket_bound_full(ipv6, src_port, interface, None, None)
 }
 
 /// Create a DGRAM UDP socket bound to source port, interface, and optionally source IP
@@ -107,6 +107,7 @@ pub fn create_udp_dgram_socket_bound_full(
     src_port: u16,
     interface: Option<&InterfaceInfo>,
     source_ip: Option<IpAddr>,
+    scope_id: Option<u32>,
 ) -> Result<Socket> {
     let socket = create_udp_dgram_socket(ipv6)?;
 
@@ -127,9 +128,12 @@ pub fn create_udp_dgram_socket_bound_full(
     socket.set_reuse_address(true)?;
 
     // Bind to the specified source port (and optionally source IP)
-    let bind_addr = match source_ip {
-        Some(ip) => SocketAddr::new(ip, src_port),
-        None => {
+    let bind_addr = match (source_ip, scope_id) {
+        (Some(IpAddr::V6(v6)), Some(scope)) => {
+            SocketAddr::V6(std::net::SocketAddrV6::new(v6, src_port, 0, scope))
+        }
+        (Some(ip), _) => SocketAddr::new(ip, src_port),
+        (None, _) => {
             if ipv6 {
                 SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), src_port)
             } else {

--- a/src/trace/engine.rs
+++ b/src/trace/engine.rs
@@ -106,7 +106,8 @@ impl ProbeEngine {
         // Skip binding if source is unspecified (:: or 0.0.0.0) - let kernel choose.
         if (self.config.source_ip.is_some() || ipv6)
             && !src_ip.is_unspecified()
-            && let Err(e) = bind_to_source_ip(&socket_info.socket, src_ip)
+            && let Err(e) =
+                bind_to_source_ip(&socket_info.socket, src_ip, self.config.source_ip_scope_id)
         {
             if self.config.source_ip.is_some() {
                 // User explicitly requested this source IP - hard fail
@@ -136,8 +137,13 @@ impl ProbeEngine {
         src_port: u16,
         source_ip: Option<IpAddr>,
     ) -> Result<Socket> {
-        let socket =
-            create_udp_dgram_socket_bound_full(ipv6, src_port, self.interface.as_ref(), source_ip)?;
+        let socket = create_udp_dgram_socket_bound_full(
+            ipv6,
+            src_port,
+            self.interface.as_ref(),
+            source_ip,
+            self.config.source_ip_scope_id,
+        )?;
         if let Some(dscp) = self.config.dscp
             && let Err(e) = set_dscp(&socket, dscp, ipv6)
         {
@@ -154,7 +160,7 @@ impl ProbeEngine {
     fn build_tcp_send_socket(&self, ipv6: bool) -> Result<Socket> {
         let socket = create_tcp_socket_with_interface(ipv6, self.interface.as_ref())?;
         if let Some(source_ip) = self.config.source_ip {
-            bind_to_source_ip(&socket, source_ip)?;
+            bind_to_source_ip(&socket, source_ip, self.config.source_ip_scope_id)?;
         }
         if let Some(dscp) = self.config.dscp
             && let Err(e) = set_dscp(&socket, dscp, ipv6)

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -46,6 +46,9 @@ const MAX_DRAIN_BATCH: usize = 100;
 struct BatchedResponse {
     probe_id: ProbeId,
     responder: IpAddr,
+    /// IPv6 scope ID for link-local responders (from sin6_scope_id)
+    #[allow(dead_code)]
+    responder_scope_id: Option<u32>,
     rtt: Duration,
     mpls_labels: Option<Vec<MplsLabel>>,
     response_type: IcmpResponseType,
@@ -197,6 +200,8 @@ impl Receiver {
                         // Reset consecutive error count on successful receive
                         self.consecutive_errors = 0;
                         batch_count += 1;
+                        // scope_id from the source address (non-zero for IPv6 link-local)
+                        let responder_scope_id = recv_result.scope_id;
 
                         if let Some(parsed) = parse_icmp_response(
                             &buffer[..recv_result.len],
@@ -264,6 +269,7 @@ impl Receiver {
                                 batch.push(BatchedResponse {
                                     probe_id: parsed.probe_id,
                                     responder: parsed.responder,
+                                    responder_scope_id,
                                     rtt,
                                     mpls_labels: parsed.mpls_labels,
                                     response_type: parsed.response_type,


### PR DESCRIPTION
## Summary

Fixes IPv6 link-local scope ID being dropped on receiving and binding (LAN-143).

### Receiving

`parse_sockaddr_storage` now extracts `sin6_scope_id` from `sockaddr_in6` and returns it alongside `IpAddr`. `RecvResult` carries the `scope_id` so link-local responders can be disambiguated by interface.

### Binding

`--source-ip` now accepts IPv6 zone IDs (`fe80::1%eth0` or `fe80::1%5`). The zone is resolved to a numeric scope_id via `if_nametoindex` (for interface names) or parsed directly (for numeric IDs). `bind_to_source_ip` and `create_udp_dgram_socket_bound_full` accept an optional scope_id and construct `SocketAddrV6` for link-local binds.

### Config

`Config` gains `source_ip_scope_id: Option<u32>`, threaded through the engine's ICMP, UDP, and TCP bind paths. CLI `--source-ip` is now `Option<String>` (was `Option<IpAddr>`) to accept zone syntax; the IP is parsed in `validate()`.

## Testing

- All 577 tests pass (including 8 new tests)
- `cargo clippy --all-targets -- -D warnings` clean
- New tests:
  - `test_parse_sockaddr_storage_ipv6_scope_id` — link-local with scope_id=3
  - `test_parse_sockaddr_storage_ipv6_no_scope_id` — global IPv6, scope_id=None
  - `test_parse_sockaddr_storage_ipv4` — IPv4, scope_id=None
  - `test_source_ip_plain_ipv4` — plain IPv4, no zone
  - `test_source_ip_plain_ipv6` — plain IPv6, no zone
  - `test_source_ip_ipv6_numeric_scope` — `fe80::1%5` → scope_id=5
  - `test_source_ip_invalid_ip` — rejects bad IP
  - `test_source_ip_invalid_zone_interface` — rejects unknown interface name

Closes LAN-143.