### PR TITLE
fix: TUI async polling, replay validation, assert→Result (LAN-150, LAN-181)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -427,6 +427,18 @@ impl Args {
                 }
             }
         }
+
+        // Reject nonsensical flag combinations in replay/diff modes.
+        // These modes don't probe, so probing-related flags are meaningless.
+        if self.replay.is_some() || self.diff.is_some() {
+            if self.pmtud {
+                return Err("--pmtud cannot be used with --replay or --diff".into());
+            }
+            if self.jumbo {
+                return Err("--jumbo cannot be used with --replay or --diff".into());
+            }
+        }
+
         Ok(())
     }
 }
@@ -781,5 +793,51 @@ mod tests {
         .unwrap();
         assert!(args.daemon && args.stream_json);
         assert!(args.is_headless());
+    }
+
+    #[test]
+    fn test_pmtud_rejected_with_replay() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--replay", "session.json", "--pmtud"]).unwrap();
+        let err = args.validate().unwrap_err();
+        assert!(
+            err.contains("--pmtud"),
+            "error should mention --pmtud: {err}"
+        );
+    }
+
+    #[test]
+    fn test_jumbo_rejected_with_replay() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--replay", "session.json", "--pmtud", "--jumbo"])
+                .unwrap();
+        let err = args.validate().unwrap_err();
+        assert!(
+            err.contains("--pmtud") || err.contains("--jumbo"),
+            "error should mention --pmtud or --jumbo: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pmtud_rejected_with_diff() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--diff", "a.json", "b.json", "--pmtud"]).unwrap();
+        let err = args.validate().unwrap_err();
+        assert!(
+            err.contains("--pmtud"),
+            "error should mention --pmtud: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_passes_for_plain_replay() {
+        let mut args = Args::try_parse_from(["ttl", "--replay", "session.json"]).unwrap();
+        assert!(args.validate().is_ok(), "plain --replay should validate");
+    }
+
+    #[test]
+    fn test_validate_passes_for_plain_diff() {
+        let mut args = Args::try_parse_from(["ttl", "--diff", "a.json", "b.json"]).unwrap();
+        assert!(args.validate().is_ok(), "plain --diff should validate");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -815,13 +815,17 @@ mod tests {
 
     #[test]
     fn test_jumbo_rejected_with_replay() {
-        let mut args =
-            Args::try_parse_from(["ttl", "--replay", "session.json", "--pmtud", "--jumbo"])
-                .unwrap();
+        // Construct directly so this test exercises the `jumbo` validation branch
+        // rather than being short-circuited by the earlier `pmtud` check.
+        let mut args = make_args(|a| {
+            a.targets.clear();
+            a.replay = Some("session.json".to_string());
+            a.jumbo = true;
+        });
         let err = args.validate().unwrap_err();
         assert!(
-            err.contains("--pmtud") || err.contains("--jumbo"),
-            "error should mention --pmtud or --jumbo: {err}"
+            err.contains("--jumbo"),
+            "error should mention --jumbo: {err}"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -263,13 +263,20 @@ impl Args {
 
     /// Validate arguments
     pub fn validate(&mut self) -> Result<(), String> {
+        // Replay/diff modes don't probe — they load saved sessions and
+        // export/diff them. Skip live-probe validations for those modes.
+        let replay_or_diff = self.replay.is_some() || self.diff.is_some();
+
         // Interactive TUI mode supports starting empty (add targets with 'o');
         // every other mode needs at least one target up front
-        if self.targets.is_empty() && (self.is_batch_mode() || self.is_headless()) {
+        if !replay_or_diff
+            && self.targets.is_empty()
+            && (self.is_batch_mode() || self.is_headless())
+        {
             return Err("No targets specified (required for non-interactive modes)".into());
         }
 
-        if self.is_batch_mode() && self.count == 0 {
+        if !replay_or_diff && self.is_batch_mode() && self.count == 0 {
             return Err("Batch output modes (--json, --csv, --report) require -c to be set".into());
         }
 
@@ -839,5 +846,38 @@ mod tests {
     fn test_validate_passes_for_plain_diff() {
         let mut args = Args::try_parse_from(["ttl", "--diff", "a.json", "b.json"]).unwrap();
         assert!(args.validate().is_ok(), "plain --diff should validate");
+    }
+
+    #[test]
+    fn test_replay_with_json_validates() {
+        let mut args = Args::try_parse_from(["ttl", "--replay", "session.json", "--json"]).unwrap();
+        assert!(args.validate().is_ok(), "--replay --json should validate");
+    }
+
+    #[test]
+    fn test_replay_with_csv_validates() {
+        let mut args = Args::try_parse_from(["ttl", "--replay", "session.json", "--csv"]).unwrap();
+        assert!(args.validate().is_ok(), "--replay --csv should validate");
+    }
+
+    #[test]
+    fn test_replay_with_report_validates() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--replay", "session.json", "--report"]).unwrap();
+        assert!(args.validate().is_ok(), "--replay --report should validate");
+    }
+
+    #[test]
+    fn test_replay_with_no_tui_validates() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--replay", "session.json", "--no-tui"]).unwrap();
+        assert!(args.validate().is_ok(), "--replay --no-tui should validate");
+    }
+
+    #[test]
+    fn test_diff_with_json_validates() {
+        let mut args =
+            Args::try_parse_from(["ttl", "--diff", "a.json", "b.json", "--json"]).unwrap();
+        assert!(args.validate().is_ok(), "--diff --json should validate");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,17 @@ use tui::views::target_input::{AddTargetRequest, AddedTarget};
 async fn main() -> Result<()> {
     let mut args = Args::parse();
 
-    // Handle shell completion generation (instant, no update check needed)
+    // Handle shell completion generation (instant, no validation needed)
     if let Some(ref shell) = args.completions {
         generate_completions(shell);
         return Ok(());
+    }
+
+    // Validate before any mode dispatch so replay/diff also catch bad flags
+    // (e.g., --pmtud with --replay, nonsensical port/TTL combos).
+    if let Err(e) = args.validate() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
     }
 
     // Handle replay mode (quick viewing operation, no update check)
@@ -70,12 +77,6 @@ async fn main() -> Result<()> {
         let result = update::check_for_update();
         let _ = update_tx.send(result); // Ignore if receiver dropped
     });
-
-    // Validate arguments
-    if let Err(e) = args.validate() {
-        eprintln!("Error: {}", e);
-        std::process::exit(1);
-    }
 
     // Check permissions early
     if let Err(e) = check_permissions() {

--- a/src/probe/rawip.rs
+++ b/src/probe/rawip.rs
@@ -175,18 +175,17 @@ pub fn build_ipv4_packet(
     tos: u8,
     dont_fragment: bool,
     transport: &[u8],
-) -> Vec<u8> {
+) -> Result<Vec<u8>> {
     let total_payload = IPV4_HEADER_SIZE + transport.len();
-    assert!(
-        total_payload <= u16::MAX as usize,
-        "IPv4 packet too large: {total_payload} bytes (max 65535)"
-    );
+    if total_payload > u16::MAX as usize {
+        anyhow::bail!("IPv4 packet too large: {total_payload} bytes (max 65535)");
+    }
     let total_len = total_payload as u16;
     let header = build_ipv4_header(src, dst, protocol, ttl, tos, total_len, 0, dont_fragment);
     let mut packet = Vec::with_capacity(total_payload);
     packet.extend_from_slice(&header);
     packet.extend_from_slice(transport);
-    packet
+    Ok(packet)
 }
 
 /// Create a raw IPv4 socket with `IP_HDRINCL` enabled, optionally bound to an
@@ -383,7 +382,7 @@ mod tests {
         let src = Ipv4Addr::new(1, 2, 3, 4);
         let dst = Ipv4Addr::new(5, 6, 7, 8);
         let transport = vec![0xAAu8; 16];
-        let pkt = build_ipv4_packet(src, dst, IPPROTO_TCP, 12, 0, true, &transport);
+        let pkt = build_ipv4_packet(src, dst, IPPROTO_TCP, 12, 0, true, &transport).unwrap();
 
         assert_eq!(pkt.len(), IPV4_HEADER_SIZE + transport.len());
         assert_eq!(pkt[8], 12, "TTL in header");
@@ -416,16 +415,16 @@ mod tests {
             0,
             false,
             &transport,
-        );
+        )
+        .expect("max-size packet should build successfully");
         assert_eq!(pkt.len(), u16::MAX as usize);
     }
 
     #[test]
-    #[should_panic(expected = "IPv4 packet too large")]
-    fn test_build_ipv4_packet_oversized_panics() {
+    fn test_build_ipv4_packet_oversized_returns_err() {
         let oversized = u16::MAX as usize - IPV4_HEADER_SIZE + 1;
         let transport = vec![0u8; oversized];
-        build_ipv4_packet(
+        let result = build_ipv4_packet(
             Ipv4Addr::new(1, 2, 3, 4),
             Ipv4Addr::new(5, 6, 7, 8),
             IPPROTO_ICMP,
@@ -433,6 +432,12 @@ mod tests {
             0,
             false,
             &transport,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("too large"),
+            "error should mention 'too large': {err}"
         );
     }
 
@@ -445,7 +450,7 @@ mod tests {
         let src = Ipv4Addr::new(192, 168, 0, 1);
         let dst = Ipv4Addr::new(9, 9, 9, 9);
         let transport = vec![0u8; 12];
-        let pkt = build_ipv4_packet(src, dst, IPPROTO_ICMP, 5, 0x20, false, &transport);
+        let pkt = build_ipv4_packet(src, dst, IPPROTO_ICMP, 5, 0x20, false, &transport).unwrap();
 
         let parsed = Ipv4Packet::new(&pkt).expect("valid IPv4 packet");
         assert_eq!(parsed.get_version(), 4);
@@ -487,13 +492,13 @@ mod tests {
 
         // ICMP echo.
         let icmp = build_echo_request(0x4242, 1, 16, false, None, false);
-        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 5, 0, false, &icmp);
+        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 5, 0, false, &icmp).unwrap();
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected ICMP IP_HDRINCL packet (ip_len/ip_off byte order?)");
 
         // UDP datagram.
         let udp = build_udp_datagram(lo, lo, 33434, 33500, b"ttl-probe");
-        let pkt = build_ipv4_packet(lo, lo, IPPROTO_UDP, 6, 0, false, &udp);
+        let pkt = build_ipv4_packet(lo, lo, IPPROTO_UDP, 6, 0, false, &udp).unwrap();
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected UDP IP_HDRINCL packet (ip_len/ip_off byte order?)");
 
@@ -506,13 +511,13 @@ mod tests {
             IpAddr::V4(lo),
             0,
         );
-        let pkt = build_ipv4_packet(lo, lo, IPPROTO_TCP, 7, 0, false, &tcp);
+        let pkt = build_ipv4_packet(lo, lo, IPPROTO_TCP, 7, 0, false, &tcp).unwrap();
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected TCP IP_HDRINCL packet (ip_len/ip_off byte order?)");
 
         // Also exercise the Don't Fragment path used by PMTUD.
         let icmp_df = build_echo_request(0x4242, 2, 64, false, None, false);
-        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 8, 0, true, &icmp_df);
+        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, 8, 0, true, &icmp_df).unwrap();
         send_raw_ipv4(&socket, &pkt, lo)
             .expect("kernel rejected DF IP_HDRINCL packet (ip_len/ip_off byte order?)");
     }
@@ -543,7 +548,7 @@ mod tests {
         recv.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
 
         let icmp = build_echo_request(ident, 1, 16, false, None, false);
-        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, ttl, tos, false, &icmp);
+        let pkt = build_ipv4_packet(lo, lo, IPPROTO_ICMP, ttl, tos, false, &icmp).unwrap();
         send_raw_ipv4(&send, &pkt, lo).expect("send IP_HDRINCL echo to loopback");
 
         // Loopback also yields the kernel's echo reply; read until we see our request.

--- a/src/trace/engine.rs
+++ b/src/trace/engine.rs
@@ -860,7 +860,7 @@ impl ProbeEngine {
 
                         let icmp =
                             build_echo_request(self.identifier, probe_id.to_sequence(), payload_size, false, None, false);
-                        let packet = build_ipv4_packet(src, dst, IPPROTO_ICMP, ttl, tos, false, &icmp);
+                        let packet = build_ipv4_packet(src, dst, IPPROTO_ICMP, ttl, tos, false, &icmp)?;
 
                         let sent_at = Instant::now();
                         let flow_id = 0u8;
@@ -976,7 +976,7 @@ impl ProbeEngine {
                             };
 
                             let udp = build_udp_datagram(src, dst, src_port, dst_port, &payload);
-                            let packet = build_ipv4_packet(src, dst, IPPROTO_UDP, ttl, tos, false, &udp);
+                            let packet = build_ipv4_packet(src, dst, IPPROTO_UDP, ttl, tos, false, &udp)?;
 
                             let sent_at = Instant::now();
                             {
@@ -1086,7 +1086,7 @@ impl ProbeEngine {
                                 self.target,
                                 payload_size,
                             );
-                            let packet = build_ipv4_packet(src, dst, IPPROTO_TCP, ttl, tos, false, &tcp);
+                            let packet = build_ipv4_packet(src, dst, IPPROTO_TCP, ttl, tos, false, &tcp)?;
 
                             let sent_at = Instant::now();
                             {
@@ -1331,7 +1331,13 @@ impl ProbeEngine {
             true,
         );
         // Don't Fragment set in the IP header so routers return Frag Needed.
-        let packet = build_ipv4_packet(src, dst, IPPROTO_ICMP, dest_ttl, tos, true, &icmp);
+        let packet = match build_ipv4_packet(src, dst, IPPROTO_ICMP, dest_ttl, tos, true, &icmp) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("PMTUD: Failed to build probe size {}: {}", packet_size, e);
+                return false;
+            }
+        };
 
         let sent_at = Instant::now();
         let flow_id = 0u8;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -475,6 +475,35 @@ fn adjust_replay_speed(ui_state: &mut UiState, delta: f32) {
     ui_state.set_status(format!("Speed: {:.1}x", new_speed));
 }
 
+/// Spawn a dedicated blocking thread to read crossterm events.
+///
+/// `event::poll` and `event::read` are blocking calls that must not run on the
+/// async executor — they'd stall the tokio runtime for up to `tick_rate` each
+/// iteration. This thread forwards `Event`s over a channel so the async loop
+/// can `try_recv` without blocking.
+///
+/// The thread exits when `cancel` fires or the receiver is dropped.
+fn spawn_event_reader(
+    tick_rate: Duration,
+    cancel: CancellationToken,
+) -> std::sync::mpsc::Receiver<Event> {
+    let (tx, rx) = std::sync::mpsc::channel::<Event>();
+
+    std::thread::spawn(move || {
+        while !cancel.is_cancelled() {
+            if event::poll(tick_rate).unwrap_or(false)
+                && let Ok(ev) = event::read()
+                && tx.send(ev).is_err()
+            {
+                // Receiver dropped — TUI is shutting down.
+                break;
+            }
+        }
+    });
+
+    rx
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_app<B>(
     terminal: &mut Terminal<B>,
@@ -491,6 +520,7 @@ where
     B::Error: Send + Sync + 'static,
 {
     let theme_names = Theme::list();
+    let event_rx = spawn_event_reader(tick_rate, cancel.clone());
     let ix_enabled = ix_lookup.is_some();
 
     loop {
@@ -618,10 +648,9 @@ where
             })?;
         }
 
-        // Handle input with timeout
-        if event::poll(tick_rate)?
-            && let Event::Key(key) = event::read()?
-        {
+        // Handle input — non-blocking: the event-reader thread forwards
+        // crossterm events over the channel so we never stall the async runtime.
+        if let Ok(Event::Key(key)) = event_rx.try_recv() {
             if key.kind != KeyEventKind::Press {
                 continue;
             }
@@ -1054,6 +1083,11 @@ where
                 _ => {}
             }
         }
+
+        // Yield to the async runtime so other tasks (receiver, enrichment
+        // workers, cancellation) are not starved. Previously the blocking
+        // `event::poll(tick_rate)` provided this pacing implicitly.
+        tokio::time::sleep(tick_rate).await;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Closes LAN-150 and LAN-181 — the last two open ttl issues.

## LAN-150 #32 — TUI input polling blocks async runtime

**Problem:** `event::poll(tick_rate)` and `event::read()` are blocking calls running on the tokio executor, stalling it for up to 16ms per frame iteration.

**Fix:** Spawn a dedicated `std::thread` that runs the crossterm event loop and forwards `Event` values over an `mpsc` channel. The async loop uses `try_recv()` (non-blocking) and `tokio::time::sleep(tick_rate)` for frame pacing.

**Files:** `src/tui/app.rs` — new `spawn_event_reader()` helper, `run_app` input handling switched from blocking `event::poll`/`event::read` to non-blocking `try_recv`.

## LAN-150 #22 — Replay/diff bypasses CLI validation

**Problem:** `args.validate()` ran after the replay/diff early returns in `main()`, so nonsensical flags (e.g. `--pmtud --replay`) were accepted silently.

**Fix:** Move `validate()` before the early returns. Add validation rules rejecting `--pmtud` and `--jumbo` in replay/diff modes.

**Files:** `src/main.rs`, `src/cli.rs`.

## LAN-181 — assert\! in build_ipv4_packet production path panics

**Problem:** `build_ipv4_packet` used `assert!` to guard against oversized IPv4 packets — a production panic path.

**Fix:** Convert to `Result<Vec<u8>>` using `anyhow::bail!`. All 4 production callers in `engine.rs` updated: 3 use `?` (in `Result`-returning functions), 1 (PMTUD `bool` fn) handles `Err` with `eprintln!` + `return false`.

**Files:** `src/probe/rawip.rs`, `src/trace/engine.rs`.

## Tests

- `test_build_ipv4_packet_oversized_returns_err` — replaces `should_panic` with `is_err` + error message check
- `test_pmtud_rejected_with_replay` — validates --pmtud + --replay is rejected
- `test_jumbo_rejected_with_replay` — validates --jumbo + --replay is rejected
- `test_pmtud_rejected_with_diff` — validates --pmtud + --diff is rejected
- `test_validate_passes_for_plain_replay` — plain --replay still validates
- `test_validate_passes_for_plain_diff` — plain --diff still validates

All 603 tests pass, clippy clean.