### PR TITLE
refactor: use PMTUD_MARKER const for the payload marker write

### DIFF
--- a/src/probe/icmp.rs
+++ b/src/probe/icmp.rs
@@ -130,7 +130,7 @@ pub fn build_echo_request(
     // Byte 8: PMTUD marker (0x50='P' for PMTUD, 0x00 for normal)
     // Normal probes set this to pattern index 0 (= 0x00) via the loop below.
     if payload.len() > 8 && pmtud {
-        payload[8] = 0x50;
+        payload[8] = PMTUD_MARKER;
     }
 
     // Fill rest with pattern (byte 8 onwards; PMTUD marker already set above)


### PR DESCRIPTION
The receiver already matches PMTUD echo replies on `icmp::PMTUD_MARKER`, but the send side wrote the bare literal `0x50`. Use the const on both sides so the write and read can't drift apart. No behavior change — the values are identical.
