### PR TITLE
ci: harden workflow coverage and automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,14 +12,21 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo-audit
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-0.21
+
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: command -v cargo-audit || cargo install cargo-audit --locked
 
       - name: Run security audit
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -27,6 +32,11 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      - name: Check docs
+        run: cargo doc --locked --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
+
       # Real-kernel validation of the IP_HDRINCL send path (issue #12 fix): the ignored
       # test crafts IPv4 ICMP/UDP/TCP packets and sends them via a raw IP_HDRINCL socket,
       # which only succeeds if this OS's ip_len/ip_off byte order is correct (BSD kernels
@@ -39,13 +49,14 @@ jobs:
           sudo "$BIN" runtime_hdrincl --ignored --nocapture
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check
 
   build-macos:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -77,6 +88,7 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -87,10 +99,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check MSRV
-        run: cargo check --verbose
+        run: cargo check --all-targets --locked --verbose
+
+      - name: Test MSRV lib
+        run: cargo test --lib --locked --verbose
 
   build-freebsd:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/src/probe/icmp.rs
+++ b/src/probe/icmp.rs
@@ -9,7 +9,7 @@ pub const ICMP_HEADER_SIZE: usize = 8;
 pub const DEFAULT_PAYLOAD_SIZE: usize = 56;
 /// Minimum payload size (4 bytes ProbeId + 4 bytes timestamp)
 pub const MIN_PAYLOAD_SIZE: usize = 8;
-/// PMTUD marker byte written to payload[8] to distinguish PMTUD probes.
+/// PMTUD marker byte written to `payload[8]` to distinguish PMTUD probes.
 /// Echo Replies echo the payload verbatim, so the receiver can detect
 /// PMTUD success without a separate ICMP identifier.
 pub const PMTUD_MARKER: u8 = 0x50; // 'P'


### PR DESCRIPTION
## Summary

- run Linux clippy with `--all-targets` to match macOS, FreeBSD, and CONTRIBUTING.md
- add rustdoc warning checks with `RUSTDOCFLAGS=-D warnings`
- strengthen MSRV validation with `--all-targets --locked` check plus `cargo test --lib --locked`
- add workflow concurrency cancellation and per-job timeouts
- cache `cargo-audit` in the audit workflow
- group weekly Dependabot Cargo and GitHub Actions updates
- fix an existing rustdoc warning in the PMTUD marker comment exposed by the new doc gate

## Validation

- `cargo test -q --lib --tests`
- `cargo clippy --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --document-private-items`
- `cargo +1.88 check --all-targets --locked --verbose`
- `cargo +1.88 test --lib --locked --verbose`
- YAML parsed locally for CI, audit, and Dependabot configs
