### PR TITLE
feat(update): allow disabling the update check (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Opt out of the startup update check** (#110). The GitHub release check can now be disabled five ways: the `--no-update-check` flag, the `DO_NOT_TRACK=1` (cross-tool standard) or `TTL_NO_UPDATE_CHECK=1` environment variables, a `no_update_check = true` preference in `~/.config/ttl/config.toml`, the **Update Check** toggle in the TUI Settings modal, or a build with `--no-default-features`, which compiles the check out entirely and drops the `update-informer` dependency. Addresses package-repository, air-gapped, and privacy use cases where an unconditional phone-home is unexpected. An [`examples/config.toml`](examples/config.toml) now documents the available preferences.
+
 ## [0.20.2] - 2026-07-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ repository = "https://github.com/lance0/ttl"
 keywords = ["traceroute", "mtr", "network", "tui", "diagnostics"]
 categories = ["command-line-utilities", "network-programming"]
 
+[features]
+default = ["update-check"]
+# Bundles the startup version check (a network call to the GitHub releases API).
+# Packagers can drop it entirely with `--no-default-features`, which also drops
+# the update-informer dependency.
+update-check = ["dep:update-informer"]
+
 [dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -58,7 +65,7 @@ scopeguard = "1"
 dirs = "6.0"
 
 # Update notifications
-update-informer = { version = "1", default-features = false, features = ["github", "ureq", "rustls-tls"] }
+update-informer = { version = "1", default-features = false, features = ["github", "ureq", "rustls-tls"], optional = true }
 
 # TTY detection
 is-terminal = "0.4"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [Installation](#installation) below for setup instructions.
 - **MPLS label detection** from ICMP extensions
 - **ICMP, UDP, TCP probing** with auto-detection
 - **Great TUI** with themes, sparklines, and session export
-- **Update notifications** - in-app banner when new versions are available
+- **Update notifications** - in-app banner when new versions are available (opt out via `--no-update-check`, `DO_NOT_TRACK`, config, or a `--no-default-features` build)
 - **Scriptable** - JSON, CSV, text report, and line-delimited JSON streaming output
 - **Trace diffing** - compare two saved sessions for path and latency changes
 - **Daemon mode + Prometheus exporter** - headless continuous monitoring with `/metrics` and `/healthz`
@@ -225,6 +225,7 @@ ttl --interface eth0 host      # Bind to interface
 ttl --size 1400 host           # Large packets for MTU testing
 ttl --dscp 46 host             # QoS marking (EF)
 ttl --wide host                # Wide mode for wider terminals
+ttl --no-update-check host     # Skip the startup release check (see also DO_NOT_TRACK)
 ```
 
 See [docs/FEATURES.md](docs/FEATURES.md) for full CLI reference.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -419,6 +419,7 @@ Press `s` to open the settings modal. Configure:
 - **Theme**: Select from 11 built-in themes with live preview
 - **Display Mode**: Control column widths (auto/compact/wide)
 - **PeeringDB**: Configure API key and view cache status (only shown when IX detection is enabled)
+- **Update Check**: Toggle the startup check for new releases on/off (persisted to config)
 
 ### Navigation
 
@@ -426,7 +427,7 @@ Press `s` to open the settings modal. Configure:
 |-----|--------|
 | `Tab` | Switch between sections |
 | `Up`/`Down` or `j`/`k` | Navigate within section |
-| `Enter` or `Space` | Cycle option (theme/display mode) |
+| `Enter` or `Space` | Cycle option (theme/display mode) or toggle update check |
 | `r` | Refresh PeeringDB cache (in PeeringDB section) |
 | `Esc` | Close and save |
 
@@ -482,6 +483,21 @@ ttl checks GitHub releases for new versions in a background thread at startup. T
   - Cargo: `cargo install ttl`
   - Pre-built binary: link to GitHub releases
 - **Non-interactive mode**: Update notice is printed to stderr after the run completes (JSON/CSV/report modes)
+
+### Disabling the update check
+
+The check can be turned off — useful for packaged installs, air-gapped hosts, or
+privacy. Any of these opts out (checked in this order):
+
+- **Per run**: `ttl --no-update-check <target>`
+- **Environment**: `DO_NOT_TRACK=1` (the [cross-tool standard](https://consoledonottrack.com/))
+  or `TTL_NO_UPDATE_CHECK=1`. Any value other than empty/`0`/`false` counts as set.
+- **Persistent**: `no_update_check = true` in `~/.config/ttl/config.toml` (see
+  [`examples/config.toml`](../examples/config.toml)), or toggle **Update Check**
+  off in the Settings modal (`s`), which saves the preference.
+- **Compile-time**: build with `--no-default-features` to drop the check — and the
+  `update-informer` dependency — entirely. Package maintainers can ship a build
+  that never phones home.
 
 ## Output Formats
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,21 @@
+# ttl configuration file
+# Place at ~/.config/ttl/config.toml
+#
+# ttl writes this file itself when you change settings in the TUI (theme,
+# display mode, PeeringDB key). You can also edit it by hand. Every key is
+# optional; omitted keys use the built-in defaults.
+
+# Color theme: default, kawaii, cyber, dracula, monochrome, matrix, nord,
+# gruvbox, catppuccin, tokyo_night, solarized
+theme = "default"
+
+# Column width mode: auto, compact, or wide
+display_mode = "auto"
+
+# PeeringDB API key for higher-rate-limit IX detection lookups
+# peeringdb_api_key = "your-key-here"
+
+# Disable the background check for a newer ttl release. Also honored via the
+# DO_NOT_TRACK or TTL_NO_UPDATE_CHECK environment variables, the
+# --no-update-check flag, or the Update Check toggle in the TUI settings.
+no_update_check = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,6 +124,11 @@ pub struct Args {
     #[arg(long = "no-tui")]
     pub no_tui: bool,
 
+    /// Skip the startup check for new releases (also honors DO_NOT_TRACK=1 or
+    /// TTL_NO_UPDATE_CHECK=1, or a saved `update_check = false` preference)
+    #[arg(long = "no-update-check")]
+    pub no_update_check: bool,
+
     /// Output JSON (batch mode, requires -c)
     #[arg(long = "json")]
     pub json: bool,
@@ -475,6 +480,7 @@ mod tests {
             no_ix: false,
             geoip_db: None,
             no_tui: false,
+            no_update_check: false,
             json: false,
             csv: false,
             report: false,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,7 +125,7 @@ pub struct Args {
     pub no_tui: bool,
 
     /// Skip the startup check for new releases (also honors DO_NOT_TRACK=1 or
-    /// TTL_NO_UPDATE_CHECK=1, or a saved `update_check = false` preference)
+    /// TTL_NO_UPDATE_CHECK=1, or a saved `no_update_check = true` preference)
     #[arg(long = "no-update-check")]
     pub no_update_check: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,13 +70,26 @@ async fn main() -> Result<()> {
         return run_diff_mode(&diff_files[0], &diff_files[1], args.json);
     }
 
-    // Spawn background update check after early exits
-    // Uses channel for non-blocking result retrieval at exit
-    let (update_tx, update_rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let result = update::check_for_update();
-        let _ = update_tx.send(result); // Ignore if receiver dropped
-    });
+    // Spawn background update check after early exits, unless opted out by any
+    // source. Precedence (higher wins): compiled-out > env (DO_NOT_TRACK /
+    // TTL_NO_UPDATE_CHECK) > --no-update-check flag > saved `no_update_check`
+    // preference. Uses a channel for non-blocking result retrieval at exit.
+    // ponytail: re-reads the tiny prefs TOML here (the TUI reloads it later); a
+    // full prefs-threading refactor isn't worth it for one small file read.
+    let update_disabled = update::check_disabled(
+        update::env_opt_out(),
+        args.no_update_check,
+        Prefs::load().no_update_check,
+    );
+    let update_rx = if update_disabled {
+        None
+    } else {
+        let (update_tx, update_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = update_tx.send(update::check_for_update()); // Ignore if receiver dropped
+        });
+        Some(update_rx)
+    };
 
     // Check permissions early
     if let Err(e) = check_permissions() {
@@ -358,7 +371,8 @@ async fn main() -> Result<()> {
 
     // Check for update notification (only for non-interactive mode)
     // Use short timeout so we don't delay exit if check is slow
-    if is_terminal::is_terminal(std::io::stderr())
+    if let Some(update_rx) = update_rx
+        && is_terminal::is_terminal(std::io::stderr())
         && let Ok(Some(new_version)) = update_rx.recv_timeout(Duration::from_millis(100))
     {
         update::print_update_notice(&new_version);
@@ -783,7 +797,7 @@ async fn run_interactive_mode(
     cancel: CancellationToken,
     interface: Option<InterfaceInfo>,
     resolve_info: Option<ResolveInfo>,
-    update_rx: std::sync::mpsc::Receiver<Option<String>>,
+    update_rx: Option<std::sync::mpsc::Receiver<Option<String>>>,
 ) -> Result<()> {
     // Shared pending map for probe correlation (engine writes, receiver reads)
     let pending = new_pending_map();
@@ -940,7 +954,7 @@ async fn run_interactive_mode(
         prefs,
         resolve_info,
         ix_lookup.clone(),
-        Some(update_rx),
+        update_rx,
         None, // replay_state (live mode)
         Some(add_target_tx),
     )

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -49,6 +49,11 @@ pub struct Prefs {
     /// PeeringDB API key for higher rate limits on IX detection
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peeringdb_api_key: Option<String>,
+    /// Disable the background check for a newer ttl release. Absent/`None` means
+    /// enabled (the default); `true` opts out. Also overridable per-run via
+    /// --no-update-check or the DO_NOT_TRACK / TTL_NO_UPDATE_CHECK env vars.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_update_check: Option<bool>,
 }
 
 impl Prefs {
@@ -137,6 +142,24 @@ mod tests {
         assert!(prefs.theme.is_none());
         assert!(prefs.display_mode.is_none());
         assert!(prefs.peeringdb_api_key.is_none());
+        assert!(prefs.no_update_check.is_none());
+    }
+
+    #[test]
+    fn test_prefs_no_update_check_roundtrip() {
+        // Some(true) is persisted; None is omitted (default = enabled).
+        let opted_out = Prefs {
+            no_update_check: Some(true),
+            ..Default::default()
+        };
+        let toml_str = toml::to_string_pretty(&opted_out).unwrap();
+        assert!(toml_str.contains("no_update_check = true"));
+        let loaded: Prefs = toml::from_str(&toml_str).unwrap();
+        assert_eq!(loaded.no_update_check, Some(true));
+
+        let default = Prefs::default();
+        let toml_str = toml::to_string_pretty(&default).unwrap();
+        assert!(!toml_str.contains("no_update_check"));
     }
 
     #[test]
@@ -145,6 +168,7 @@ mod tests {
             theme: Some("dracula".to_string()),
             display_mode: Some(DisplayMode::Wide),
             peeringdb_api_key: Some("test_api_key_123".to_string()),
+            no_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("theme = \"dracula\""));
@@ -166,6 +190,7 @@ mod tests {
             theme: Some("default".to_string()),
             display_mode: None,
             peeringdb_api_key: None,
+            no_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         // peeringdb_api_key should be omitted when None
@@ -208,6 +233,7 @@ mod tests {
             theme: None,
             display_mode: Some(DisplayMode::Auto),
             peeringdb_api_key: None,
+            no_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("display_mode = \"auto\""));
@@ -219,6 +245,7 @@ mod tests {
             theme: None,
             display_mode: Some(DisplayMode::Compact),
             peeringdb_api_key: None,
+            no_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("display_mode = \"compact\""));
@@ -230,6 +257,7 @@ mod tests {
             theme: None,
             display_mode: Some(DisplayMode::Wide),
             peeringdb_api_key: None,
+            no_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("display_mode = \"wide\""));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -165,10 +165,14 @@ pub async fn run_tui(
     let display_mode = initial_prefs.display_mode.unwrap_or_default();
     let api_key = initial_prefs.peeringdb_api_key.clone();
 
+    let mut settings = SettingsState::new(initial_index, display_mode, api_key);
+    // Toggle shows "enabled"; the pref stores the negated "disabled" form.
+    settings.update_check = !initial_prefs.no_update_check.unwrap_or(false);
+
     let mut ui_state = UiState {
         theme_index: initial_index,
         display_mode,
-        settings: SettingsState::new(initial_index, display_mode, api_key),
+        settings,
         update_rx,
         replay_state,
         ..Default::default()
@@ -216,6 +220,8 @@ pub async fn run_tui(
         theme: Some(theme_names[ui_state.theme_index].to_string()),
         display_mode: Some(ui_state.display_mode),
         peeringdb_api_key: final_api_key,
+        // Toggle holds "enabled"; persist the negated "disabled" form.
+        no_update_check: Some(!ui_state.settings.update_check),
     })
 }
 
@@ -747,9 +753,15 @@ where
                         ui_state.settings.next_section(ix_enabled);
                     }
                     KeyCode::Enter | KeyCode::Char(' ') => {
-                        ui_state.settings.select();
-                        // Live preview display mode changes
-                        ui_state.display_mode = ui_state.settings.display_mode;
+                        if ui_state.settings.selected_section
+                            == SettingsState::update_check_section(ix_enabled)
+                        {
+                            ui_state.settings.update_check = !ui_state.settings.update_check;
+                        } else {
+                            ui_state.settings.select();
+                            // Live preview display mode changes
+                            ui_state.display_mode = ui_state.settings.display_mode;
+                        }
                     }
                     _ => {}
                 }
@@ -952,17 +964,20 @@ where
                     ui_state.set_status(format!("Display: {}", ui_state.display_mode.label()));
                 }
                 KeyCode::Char('s') => {
-                    // Open settings modal - preserve existing API key
+                    // Open settings modal - preserve existing API key and the
+                    // update-check toggle across opens.
                     let current_api_key = if ui_state.settings.api_key.is_empty() {
                         None
                     } else {
                         Some(ui_state.settings.api_key.clone())
                     };
+                    let update_check = ui_state.settings.update_check;
                     ui_state.settings = SettingsState::new(
                         ui_state.theme_index,
                         ui_state.display_mode,
                         current_api_key,
                     );
+                    ui_state.settings.update_check = update_check;
                     ui_state.show_settings = true;
                 }
                 // Open target input modal (live mode only)

--- a/src/tui/views/settings.rs
+++ b/src/tui/views/settings.rs
@@ -23,6 +23,8 @@ pub struct SettingsState {
     pub api_key: String,
     /// Cursor position in API key input
     pub api_key_cursor: usize,
+    /// Whether the startup update check is enabled (persisted to prefs)
+    pub update_check: bool,
 }
 
 impl SettingsState {
@@ -36,7 +38,15 @@ impl SettingsState {
             display_mode,
             api_key,
             api_key_cursor: cursor,
+            // Caller overrides from prefs; enabled is the default.
+            update_check: true,
         }
+    }
+
+    /// Section index of the Update Check toggle. It sits after the optional
+    /// PeeringDB section, so its index depends on whether IX detection is on.
+    pub fn update_check_section(ix_enabled: bool) -> usize {
+        if ix_enabled { 3 } else { 2 }
     }
 
     /// Insert a character at the cursor position
@@ -123,9 +133,10 @@ impl SettingsState {
         // Display mode section has no up/down navigation
     }
 
-    /// Switch between sections (0=Theme, 1=Display Mode, 2=PeeringDB)
+    /// Switch between sections. Order: 0=Theme, 1=Display Mode,
+    /// 2=PeeringDB (only when IX detection is enabled), then Update Check last.
     pub fn next_section(&mut self, ix_enabled: bool) {
-        let num_sections = if ix_enabled { 3 } else { 2 };
+        let num_sections = if ix_enabled { 4 } else { 3 };
         self.selected_section = (self.selected_section + 1) % num_sections;
     }
 
@@ -187,9 +198,10 @@ impl<'a> SettingsView<'a> {
 
 impl Widget for SettingsView<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Calculate centered popup area (taller if IX is enabled)
+        // Calculate centered popup area (taller if IX is enabled). The extra 4
+        // rows hold the Update Check section (blank + header + toggle + hint).
         let popup_width = 44.min(area.width.saturating_sub(4));
-        let base_height = if self.ix_enabled { 23 } else { 17 };
+        let base_height = if self.ix_enabled { 27 } else { 21 };
         let popup_height = base_height.min(area.height.saturating_sub(4));
         let popup_x = (area.width - popup_width) / 2 + area.x;
         let popup_y = (area.height - popup_height) / 2 + area.y;
@@ -391,6 +403,39 @@ impl Widget for SettingsView<'_> {
             }
         }
 
+        // Update Check section (always shown; sits after the optional PeeringDB
+        // section so its index shifts with ix_enabled).
+        lines.push(Line::from(""));
+        let uc_section = SettingsState::update_check_section(self.ix_enabled);
+        let uc_selected = self.state.selected_section == uc_section;
+        let uc_header_style = if uc_selected {
+            Style::default()
+                .fg(self.theme.header)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(self.theme.text_dim)
+        };
+        lines.push(Line::from(vec![Span::styled(
+            "  Update Check",
+            uc_header_style,
+        )]));
+        let uc_state = if self.state.update_check { "on" } else { "off" };
+        let uc_style = if uc_selected {
+            Style::default()
+                .fg(self.theme.shortcut)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(self.theme.text_dim)
+        };
+        lines.push(Line::from(vec![Span::styled(
+            format!("    [{}]  (Enter to toggle)", uc_state),
+            uc_style,
+        )]));
+        lines.push(Line::from(vec![Span::styled(
+            "    check GitHub for new releases at startup",
+            Style::default().fg(self.theme.text_dim),
+        )]));
+
         lines.push(Line::from(""));
 
         // Footer with keybindings
@@ -457,21 +502,29 @@ mod tests {
     fn test_settings_state_next_section() {
         let mut state = SettingsState::new(0, DisplayMode::Auto, None);
 
-        // Without IX enabled (2 sections)
+        // Without IX enabled: 3 sections (theme, display, update-check)
         assert_eq!(state.selected_section, 0);
         state.next_section(false);
         assert_eq!(state.selected_section, 1);
         state.next_section(false);
+        assert_eq!(state.selected_section, 2); // update-check
+        state.next_section(false);
         assert_eq!(state.selected_section, 0); // Wraps
 
-        // With IX enabled (3 sections)
+        // With IX enabled: 4 sections (theme, display, peeringdb, update-check)
         state.selected_section = 0;
         state.next_section(true);
         assert_eq!(state.selected_section, 1);
         state.next_section(true);
         assert_eq!(state.selected_section, 2);
         state.next_section(true);
+        assert_eq!(state.selected_section, 3); // update-check
+        state.next_section(true);
         assert_eq!(state.selected_section, 0); // Wraps
+
+        // Update-check section index tracks ix_enabled.
+        assert_eq!(SettingsState::update_check_section(false), 2);
+        assert_eq!(SettingsState::update_check_section(true), 3);
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,7 +4,7 @@
 //! Detects install method and shows appropriate update command.
 //!
 //! The check can be opted out of via `--no-update-check`, the `DO_NOT_TRACK`
-//! or `TTL_NO_UPDATE_CHECK` env vars, an `update_check = false` preference, or
+//! or `TTL_NO_UPDATE_CHECK` env vars, a `no_update_check = true` preference, or
 //! by building without the default `update-check` feature.
 
 /// Whether update checking was compiled in (the `update-check` feature, on by

--- a/src/update.rs
+++ b/src/update.rs
@@ -2,8 +2,42 @@
 //!
 //! Checks GitHub releases for new versions (cached, 1h interval).
 //! Detects install method and shows appropriate update command.
+//!
+//! The check can be opted out of via `--no-update-check`, the `DO_NOT_TRACK`
+//! or `TTL_NO_UPDATE_CHECK` env vars, an `update_check = false` preference, or
+//! by building without the default `update-check` feature.
 
-use update_informer::registry::GitHub;
+/// Whether update checking was compiled in (the `update-check` feature, on by
+/// default). Package builds can drop it with `--no-default-features`, which also
+/// removes the `update-informer` dependency from the tree.
+pub const ENABLED: bool = cfg!(feature = "update-check");
+
+/// True when the user opted out of the update check via environment:
+/// `DO_NOT_TRACK` (the cross-tool standard, <https://consoledonottrack.com>) or
+/// `TTL_NO_UPDATE_CHECK`.
+pub fn env_opt_out() -> bool {
+    ["DO_NOT_TRACK", "TTL_NO_UPDATE_CHECK"]
+        .iter()
+        .any(|var| std::env::var(var).is_ok_and(|v| flag_is_truthy(&v)))
+}
+
+/// A set env var counts as opt-out unless it's explicitly falsey (empty, "0",
+/// or "false"). We err toward *not* phoning home when the value is ambiguous.
+fn flag_is_truthy(v: &str) -> bool {
+    !matches!(v.trim(), "" | "0" | "false")
+}
+
+/// Resolve whether the background update check should be skipped, honoring
+/// precedence (higher layer wins): compiled-out > env opt-out > CLI flag >
+/// saved `no_update_check` preference.
+///
+/// `pref` is tristate: `Some(true)` opts out, `Some(false)` explicitly keeps
+/// the check on, and `None` (unset) falls back to the compiled-in default
+/// (enabled). ttl stores its config and TUI-saved prefs in one `config.toml`,
+/// so there is a single preference layer here (xfr splits config vs. prefs).
+pub fn check_disabled(env_opt_out: bool, cli_flag: bool, pref: Option<bool>) -> bool {
+    !ENABLED || env_opt_out || cli_flag || pref.unwrap_or(false)
+}
 
 /// How ttl was installed (best guess based on binary path)
 #[derive(Debug, Clone, Copy)]
@@ -59,9 +93,10 @@ impl InstallMethod {
 /// Uses interval(ZERO) to always perform a network check — we only call this
 /// once per process lifetime (in a background thread), so cache-based rate
 /// limiting is unnecessary.
+#[cfg(feature = "update-check")]
 pub fn check_for_update() -> Option<String> {
     use std::time::Duration;
-    use update_informer::Check;
+    use update_informer::{Check, registry::GitHub};
 
     let informer = update_informer::new(GitHub, "lance0/ttl", env!("CARGO_PKG_VERSION"))
         .interval(Duration::ZERO);
@@ -71,6 +106,12 @@ pub fn check_for_update() -> Option<String> {
         .ok()
         .flatten()
         .map(|v| v.to_string())
+}
+
+/// No-op stub when built without the `update-check` feature.
+#[cfg(not(feature = "update-check"))]
+pub fn check_for_update() -> Option<String> {
+    None
 }
 
 /// Print update notification to stderr
@@ -103,6 +144,32 @@ pub fn print_update_notice(new_version: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_flag_is_truthy() {
+        for on in ["1", "true", "yes", "on", " 1 "] {
+            assert!(flag_is_truthy(on), "{on:?} should count as opt-out");
+        }
+        for off in ["", "  ", "0", "false"] {
+            assert!(!flag_is_truthy(off), "{off:?} should not count as opt-out");
+        }
+    }
+
+    #[test]
+    fn test_check_disabled_precedence() {
+        // The tristate resolution only matters when the check is compiled in.
+        if !ENABLED {
+            assert!(check_disabled(false, false, Some(false)));
+            return;
+        }
+        // Saved pref governs when env/CLI are quiet.
+        assert!(check_disabled(false, false, Some(true))); // opt out
+        assert!(!check_disabled(false, false, Some(false))); // explicitly on
+        assert!(!check_disabled(false, false, None)); // default on
+        // env or CLI opt-out wins over an explicit pref "on".
+        assert!(check_disabled(true, false, Some(false)));
+        assert!(check_disabled(false, true, Some(false)));
+    }
 
     #[test]
     fn test_install_method_commands() {


### PR DESCRIPTION
Adds a full opt-out for the background "newer release available" check (`update-informer` → GitHub API). Requested in #110 for the standard package-manager/CI/privacy courtesy. Mirrors the xfr implementation (lance0/xfr#137) for cross-project consistency.

## How to turn it off

Precedence (first that applies wins): **compiled-out → env → CLI → config/pref**.

| Surface | How |
|---|---|
| **env** | `DO_NOT_TRACK=1` (cross-tool standard) or `TTL_NO_UPDATE_CHECK=1` |
| **CLI** | `--no-update-check` |
| **config.toml** | `no_update_check = true` in `~/.config/ttl/config.toml` (see `examples/config.toml`) |
| **TUI toggle** | Settings (`s`) → **Update Check: on/off**; persisted to config, sticks across runs |
| **compile-out** | `update-check` cargo feature (default-on); `--no-default-features` drops `update-informer` from the tree entirely — no phone-home code shipped |

## Notes

- ttl unifies config and TUI-saved prefs in one `config.toml`, so there is a single preference layer (xfr splits config vs. prefs). Resolution is the pure `update::check_disabled(env, cli, pref)`.
- The gate sits at the single spawn site in `main`, before mode dispatch, so it covers TUI, streaming, JSON/CSV/report, and daemon modes.
- Toggling off mid-run doesn't retract an already-displayed banner — it applies to the next run.

## Validation

- Builds and `clippy -D warnings` clean with **and** without default features; `fmt` clean.
- `cargo tree --no-default-features -i update-informer` → absent.
- 292 lib tests pass on both feature configs (added `check_disabled_precedence`, `flag_is_truthy`, `no_update_check` prefs roundtrip, settings section/nav).
- Behavioral check (strace, enrichment disabled so the check is the only `:443` traffic): default = 1 connect; each of `--no-update-check`, `DO_NOT_TRACK=1`, `TTL_NO_UPDATE_CHECK=1`, and `no_update_check = true` = 0; `no_update_check = false` = 1.