### PR TITLE
chore(deps): bump lru 0.18.0 → 0.18.2 (LAN-1114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,9 +1711,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]


### PR DESCRIPTION
Draft for LAN-1114 / RUSTSEC-2026-0253.

`lru` is transitive via `ratatui-core` / ratatui 0.30. **Lockfile only** (`cargo update -p lru` → **0.18.2**). No `[patch.crates-io]`. ttl does not call `LruCache::pop()`.

Clippy 1.98 nits that were previously in this branch now live in the prerequisite draft (clippy 1.98 nits). Merge that first if you want local `cargo clippy -D warnings` to pass on master; this PR does not include those files.

Not a rewrite of the Linear ticket — still the same advisory bump.