### PR TITLE
perf(tui): skip snapshot+draw when idle (LAN-1222 experiment)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use probe::{
     InterfaceInfo, check_permissions, create_send_socket_with_interface, detect_default_gateway,
     get_local_addr_with_interface, validate_interface,
 };
-use state::{Session, Target, run_ratelimit_worker};
+use state::{Session, SessionLock, Target, run_ratelimit_worker};
 use trace::engine::ProbeEngine;
 use trace::pending::{PendingMap, new_pending_map};
 use trace::receiver::{ReceiverConfig, SessionMap, spawn_receiver};
@@ -112,7 +112,7 @@ async fn main() -> Result<()> {
 
     // Resolve all targets
     let mut targets: Vec<IpAddr> = Vec::new();
-    let mut sessions_map: HashMap<IpAddr, Arc<RwLock<Session>>> = HashMap::new();
+    let mut sessions_map: HashMap<IpAddr, Arc<SessionLock>> = HashMap::new();
     let config = Config::from(&args);
     let mut effective_flows_v4 = None;
     let mut effective_flows_v6 = None;
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
                 detect_default_gateway(ipv6)
             };
 
-            sessions_map.insert(resolved_ip, Arc::new(RwLock::new(session)));
+            sessions_map.insert(resolved_ip, Arc::new(SessionLock::new(session)));
             targets.push(resolved_ip);
         }
 
@@ -212,7 +212,7 @@ async fn main() -> Result<()> {
                 detect_default_gateway(ipv6)
             };
 
-            sessions_map.insert(resolved_ip, Arc::new(RwLock::new(session)));
+            sessions_map.insert(resolved_ip, Arc::new(SessionLock::new(session)));
             targets.push(resolved_ip);
         }
 
@@ -506,11 +506,11 @@ async fn run_replay_mode(args: &Args, replay_path: &str) -> Result<()> {
         };
 
         // Show in TUI
-        let state = Arc::new(RwLock::new(session_to_display));
+        let state = Arc::new(SessionLock::new(session_to_display));
         let cancel = CancellationToken::new();
 
         // Create SessionMap with single session
-        let mut sessions_map: HashMap<IpAddr, Arc<RwLock<Session>>> = HashMap::new();
+        let mut sessions_map: HashMap<IpAddr, Arc<SessionLock>> = HashMap::new();
         sessions_map.insert(target_ip, state);
         let sessions: SessionMap = Arc::new(RwLock::new(sessions_map));
         let targets = vec![target_ip];
@@ -1126,7 +1126,7 @@ async fn run_target_manager(mut ctx: TargetManagerCtx) -> Result<()> {
             detect_default_gateway(ipv6)
         };
 
-        let state = Arc::new(RwLock::new(session));
+        let state = Arc::new(SessionLock::new(session));
         ctx.sessions.write().insert(ip, state.clone());
 
         // Spawn a receiver if this IP family doesn't have one yet
@@ -1822,7 +1822,7 @@ mod tests {
     }
 
     fn make_session_map(entries: &[(IpAddr, u8)]) -> SessionMap {
-        let mut map: HashMap<IpAddr, Arc<RwLock<Session>>> = HashMap::new();
+        let mut map: HashMap<IpAddr, Arc<SessionLock>> = HashMap::new();
         for (target_ip, flows) in entries {
             let mut target = Target::new(target_ip.to_string(), *target_ip);
             target.hostname = Some(format!("host-{}", target_ip));
@@ -1832,7 +1832,7 @@ mod tests {
             };
             map.insert(
                 *target_ip,
-                Arc::new(RwLock::new(Session::new(target, config))),
+                Arc::new(SessionLock::new(Session::new(target, config))),
             );
         }
         Arc::new(RwLock::new(map))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -268,7 +268,7 @@ async fn handle_connection(mut stream: TcpStream, sessions: SessionMap) -> Resul
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::state::{Session, Target};
+    use crate::state::{Session, SessionLock, Target};
     use parking_lot::RwLock;
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr};
@@ -292,7 +292,7 @@ mod tests {
         session.total_sent = 2;
 
         let mut map = HashMap::new();
-        map.insert(target_ip, Arc::new(RwLock::new(session)));
+        map.insert(target_ip, Arc::new(SessionLock::new(session)));
         Arc::new(RwLock::new(map))
     }
 

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -1331,6 +1331,10 @@ pub struct Session {
     /// Recorded probe events for animated replay
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<ProbeEvent>,
+    /// Bumped on hop mutation so the TUI can skip snapshot+draw when idle.
+    /// Experimental (LAN-1222); not serialized.
+    #[serde(skip)]
+    pub render_generation: u64,
 }
 
 impl Session {
@@ -1362,6 +1366,7 @@ impl Session {
             source_ip: None,
             gateway: None,
             events: Vec::new(),
+            render_generation: 0,
         }
     }
 
@@ -1379,8 +1384,14 @@ impl Session {
         if ttl == 0 || ttl as usize > self.hops.len() {
             None
         } else {
+            self.touch_render();
             Some(&mut self.hops[ttl as usize - 1])
         }
+    }
+
+    /// Mark session data as changed for TUI dirty-skip (LAN-1222 experiment).
+    pub fn touch_render(&mut self) {
+        self.render_generation = self.render_generation.wrapping_add(1);
     }
 
     /// Apply a recorded replay event to this session.
@@ -1477,6 +1488,7 @@ impl Session {
             hop.ttl_manip = None;
             hop.flap_tracking_primary = None;
         }
+        self.touch_render();
     }
 
     /// Check if NAT is detected at any hop
@@ -1507,6 +1519,7 @@ impl Session {
             source_ip: self.source_ip,
             gateway: self.gateway,
             events: Vec::new(),
+            render_generation: self.render_generation,
         }
     }
 
@@ -2606,6 +2619,25 @@ mod tests {
         assert!(session.hop(1).unwrap().ttl_manip.is_none());
     }
 
+    #[test]
+    fn test_render_generation_bumps_on_hop_mut_and_reset() {
+        let target = Target::new(
+            "test.com".to_string(),
+            IpAddr::V4(std::net::Ipv4Addr::new(1, 2, 3, 4)),
+        );
+        let mut session = Session::new(target, Config::default());
+        assert_eq!(session.render_generation, 0);
+
+        assert!(session.hop_mut(1).is_some());
+        assert_eq!(session.render_generation, 1);
+
+        session.reset_stats();
+        assert_eq!(session.render_generation, 2);
+
+        let snap = session.snapshot_for_render();
+        assert_eq!(snap.render_generation, 2);
+        assert!(snap.events.is_empty());
+    }
     #[test]
     fn test_target_new() {
         let ip = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -2,7 +2,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
+use std::ops::{Deref, DerefMut};
 use std::time::Duration;
+
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::config::Config;
 
@@ -1331,10 +1334,51 @@ pub struct Session {
     /// Recorded probe events for animated replay
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<ProbeEvent>,
-    /// Bumped on hop mutation so the TUI can skip snapshot+draw when idle.
-    /// Experimental (LAN-1222); not serialized.
+    /// Bumped every time a [`SessionLock`] write guard is released, so the TUI
+    /// can skip snapshot+draw on ticks where nothing changed. Not serialized.
     #[serde(skip)]
     pub render_generation: u64,
+}
+
+/// `RwLock<Session>` whose write guard bumps [`Session::render_generation`]
+/// on release, so every mutation path — hop stats, enrichment, PMTUD, pause —
+/// marks the TUI dirty without each writer having to remember to.
+pub struct SessionLock(RwLock<Session>);
+
+impl SessionLock {
+    pub fn new(session: Session) -> Self {
+        Self(RwLock::new(session))
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<'_, Session> {
+        self.0.read()
+    }
+
+    pub fn write(&self) -> SessionWriteGuard<'_> {
+        SessionWriteGuard(self.0.write())
+    }
+}
+
+/// Write guard for [`SessionLock`]; bumps `render_generation` when dropped.
+pub struct SessionWriteGuard<'a>(RwLockWriteGuard<'a, Session>);
+
+impl Deref for SessionWriteGuard<'_> {
+    type Target = Session;
+    fn deref(&self) -> &Session {
+        &self.0
+    }
+}
+
+impl DerefMut for SessionWriteGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Session {
+        &mut self.0
+    }
+}
+
+impl Drop for SessionWriteGuard<'_> {
+    fn drop(&mut self) {
+        self.0.render_generation = self.0.render_generation.wrapping_add(1);
+    }
 }
 
 impl Session {
@@ -1384,14 +1428,8 @@ impl Session {
         if ttl == 0 || ttl as usize > self.hops.len() {
             None
         } else {
-            self.touch_render();
             Some(&mut self.hops[ttl as usize - 1])
         }
-    }
-
-    /// Mark session data as changed for TUI dirty-skip (LAN-1222 experiment).
-    pub fn touch_render(&mut self) {
-        self.render_generation = self.render_generation.wrapping_add(1);
     }
 
     /// Apply a recorded replay event to this session.
@@ -1488,7 +1526,6 @@ impl Session {
             hop.ttl_manip = None;
             hop.flap_tracking_primary = None;
         }
-        self.touch_render();
     }
 
     /// Check if NAT is detected at any hop
@@ -2620,24 +2657,27 @@ mod tests {
     }
 
     #[test]
-    fn test_render_generation_bumps_on_hop_mut_and_reset() {
+    fn test_session_lock_write_bumps_render_generation() {
         let target = Target::new(
             "test.com".to_string(),
             IpAddr::V4(std::net::Ipv4Addr::new(1, 2, 3, 4)),
         );
-        let mut session = Session::new(target, Config::default());
-        assert_eq!(session.render_generation, 0);
+        let lock = SessionLock::new(Session::new(target, Config::default()));
+        assert_eq!(lock.read().render_generation, 0);
 
-        assert!(session.hop_mut(1).is_some());
-        assert_eq!(session.render_generation, 1);
+        // Any write-guard release bumps, regardless of which field changed.
+        lock.write().total_sent += 1;
+        assert_eq!(lock.read().render_generation, 1);
+        lock.write().reset_stats();
+        assert_eq!(lock.read().render_generation, 2);
 
-        session.reset_stats();
-        assert_eq!(session.render_generation, 2);
-
-        let snap = session.snapshot_for_render();
+        // Reads never bump.
+        let snap = lock.read().snapshot_for_render();
+        assert_eq!(lock.read().render_generation, 2);
         assert_eq!(snap.render_generation, 2);
         assert!(snap.events.is_empty());
     }
+
     #[test]
     fn test_target_new() {
         let ip = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));

--- a/src/trace/engine.rs
+++ b/src/trace/engine.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use parking_lot::RwLock;
 use socket2::Socket;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -24,7 +23,7 @@ use crate::probe::{
 use crate::probe::{enable_recv_ttl, parse_icmp_response, recv_icmp_with_ttl};
 #[cfg(target_os = "linux")]
 use crate::state::IcmpResponseType;
-use crate::state::{PmtudPhase, ProbeId, Session};
+use crate::state::{PmtudPhase, ProbeId, SessionLock};
 use crate::trace::pending::{PendingMap, PendingProbe};
 
 /// Safety cap for IPv6 echo-reply draining per tick.
@@ -37,7 +36,7 @@ pub struct ProbeEngine {
     config: Config,
     target: IpAddr,
     identifier: u16,
-    state: Arc<RwLock<Session>>,
+    state: Arc<SessionLock>,
     pending: PendingMap,
     cancel: CancellationToken,
     interface: Option<InterfaceInfo>,
@@ -47,7 +46,7 @@ impl ProbeEngine {
     pub fn new(
         config: Config,
         target: IpAddr,
-        state: Arc<RwLock<Session>>,
+        state: Arc<SessionLock>,
         pending: PendingMap,
         cancel: CancellationToken,
         interface: Option<InterfaceInfo>,
@@ -1509,6 +1508,7 @@ impl ProbeEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::Session;
     use crate::state::Target;
     use crate::trace::pending::new_pending_map;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1519,7 +1519,7 @@ mod tests {
             ..Config::default()
         };
         let target = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
-        let session = Arc::new(RwLock::new(Session::new(
+        let session = Arc::new(SessionLock::new(Session::new(
             Target::new("test".to_string(), target),
             config.clone(),
         )));

--- a/src/trace/receiver.rs
+++ b/src/trace/receiver.rs
@@ -11,12 +11,12 @@ use crate::probe::{
     recv_icmp_with_ttl,
 };
 use crate::state::{
-    IcmpResponseType, MplsLabel, PmtudPhase, ProbeEvent, ProbeId, ProbeOutcome, Session,
+    IcmpResponseType, MplsLabel, PmtudPhase, ProbeEvent, ProbeId, ProbeOutcome, SessionLock,
 };
 use crate::trace::pending::{PendingKey, PendingMap, PendingProbe};
 
 /// Map of target IP to session, shared across multiple engines and the receiver
-pub type SessionMap = Arc<RwLock<HashMap<IpAddr, Arc<RwLock<Session>>>>>;
+pub type SessionMap = Arc<RwLock<HashMap<IpAddr, Arc<SessionLock>>>>;
 
 /// Configuration for the ICMP receiver
 #[derive(Clone)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -128,6 +128,139 @@ impl UiState {
     }
 }
 
+/// Post-poll render fingerprint (LAN-1222). Built after status expiry,
+/// add-target, update check, IX cache status, and target-list refresh so
+/// idle skip cannot leave those chrome surfaces stale.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RenderFingerprint {
+    session_generation: Option<u64>,
+    selected: Option<usize>,
+    paused: bool,
+    show_help: bool,
+    show_hop_detail: bool,
+    show_settings: bool,
+    show_target_list: bool,
+    show_target_input: bool,
+    theme_index: usize,
+    display_mode: crate::prefs::DisplayMode,
+    selected_target: usize,
+    num_targets: usize,
+    target_list_index: usize,
+    status: Option<String>,
+    update_available: Option<String>,
+    replay: Option<(bool, bool, usize, u64, u32)>,
+    target_input: (String, usize, Option<String>, bool),
+    settings: (
+        usize,
+        usize,
+        usize,
+        crate::prefs::DisplayMode,
+        String,
+        usize,
+        bool,
+    ),
+    ix_cache: Option<(bool, usize, Option<u64>, bool, bool)>,
+    target_list_rows: Option<Vec<(IpAddr, String, String, String)>>,
+}
+
+fn render_fingerprint(
+    ui_state: &UiState,
+    num_targets: usize,
+    session_generation: Option<u64>,
+    cache_status: Option<&crate::lookup::ix::CacheStatus>,
+) -> RenderFingerprint {
+    let replay = ui_state.replay_state.as_ref().map(|r| {
+        (
+            r.paused,
+            r.finished,
+            r.current_index,
+            replay_current_ms(r),
+            r.speed_multiplier.to_bits(),
+        )
+    });
+    RenderFingerprint {
+        session_generation,
+        selected: ui_state.selected,
+        paused: ui_state.paused,
+        show_help: ui_state.show_help,
+        show_hop_detail: ui_state.show_hop_detail,
+        show_settings: ui_state.show_settings,
+        show_target_list: ui_state.show_target_list,
+        show_target_input: ui_state.show_target_input,
+        theme_index: ui_state.theme_index,
+        display_mode: ui_state.display_mode,
+        selected_target: ui_state.selected_target,
+        num_targets,
+        target_list_index: ui_state.target_list_index,
+        status: ui_state.status_message.as_ref().map(|(m, _)| m.clone()),
+        update_available: ui_state.update_available.clone(),
+        replay,
+        target_input: (
+            ui_state.target_input.input.clone(),
+            ui_state.target_input.cursor,
+            ui_state.target_input.error.clone(),
+            ui_state.target_input.resolving,
+        ),
+        settings: (
+            ui_state.settings.selected_section,
+            ui_state.settings.theme_scroll,
+            ui_state.settings.theme_index,
+            ui_state.settings.display_mode,
+            ui_state.settings.api_key.clone(),
+            ui_state.settings.api_key_cursor,
+            ui_state.settings.update_check,
+        ),
+        ix_cache: cache_status.map(|c| {
+            (
+                c.loaded,
+                c.prefix_count,
+                c.fetched_at,
+                c.expired,
+                c.refreshing,
+            )
+        }),
+        target_list_rows: ui_state.target_list_cache.as_ref().map(|rows| {
+            rows.iter()
+                .map(|t| {
+                    (
+                        t.ip,
+                        t.hostname.clone(),
+                        t.hops_str.clone(),
+                        t.loss_str.clone(),
+                    )
+                })
+                .collect()
+        }),
+    }
+}
+
+fn poll_update_check(ui_state: &mut UiState) {
+    if let (None, Some(rx)) = (&ui_state.update_available, &ui_state.update_rx) {
+        match rx.try_recv() {
+            Ok(result) => {
+                ui_state.update_available = result;
+                ui_state.update_rx = None;
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                ui_state.update_rx = None;
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        }
+    }
+}
+
+fn refresh_target_list_cache(ui_state: &mut UiState, sessions: &SessionMap, targets: &[IpAddr]) {
+    if ui_state.show_target_list {
+        ui_state.target_list_tick += 1;
+        if ui_state.target_list_cache.is_none() || ui_state.target_list_tick.is_multiple_of(30) {
+            ui_state.target_list_cache = Some(extract_target_infos(sessions, targets));
+        }
+    } else {
+        ui_state.target_list_cache = None;
+        ui_state.target_list_tick = 0;
+    }
+}
+
 /// Run the TUI application. Returns the final preferences for persistence.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_tui(
@@ -527,6 +660,7 @@ where
 {
     let theme_names = Theme::list();
     let event_rx = spawn_event_reader(tick_rate, cancel.clone());
+    let mut last_draw: Option<RenderFingerprint> = None;
     let ix_enabled = ix_lookup.is_some();
 
     loop {
@@ -545,20 +679,7 @@ where
         // Compute count AFTER polling so newly added targets are reflected this tick.
         let num_targets = targets.len();
 
-        // Poll for update check result (non-blocking)
-        // Drop receiver once we get any result (Some or None) or sender disconnects
-        if let (None, Some(rx)) = (&ui_state.update_available, &ui_state.update_rx) {
-            match rx.try_recv() {
-                Ok(result) => {
-                    ui_state.update_available = result;
-                    ui_state.update_rx = None;
-                }
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    ui_state.update_rx = None;
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => {}
-            }
-        }
+        poll_update_check(ui_state);
 
         // Process replay animation tick
         if let Some(ref mut replay) = ui_state.replay_state
@@ -613,47 +734,52 @@ where
         // Get cache status for settings modal
         let cache_status = ix_lookup.as_ref().map(|ix| ix.get_cache_status());
 
-        // Snapshot session data BEFORE draw so no locks are held during rendering.
-        // Uses snapshot_for_render() to skip cloning the events vec (unbounded, not used in render).
-        let session_snapshot = {
+        // Snapshot only when dirty so no locks are held during rendering.
+        refresh_target_list_cache(ui_state, &sessions, &targets);
+
+        // Fingerprint after polls so status expiry, add-target, update
+        // check, IX cache, and target-list rows participate (LAN-1222).
+        let session_generation = {
             let sessions_read = sessions.read();
             sessions_read
                 .get(&current_target)
-                .map(|state| state.read().snapshot_for_render())
+                .map(|state| state.read().render_generation)
         };
+        let fingerprint = render_fingerprint(
+            ui_state,
+            num_targets,
+            session_generation,
+            cache_status.as_ref(),
+        );
+        let dirty = last_draw.as_ref() != Some(&fingerprint);
 
-        // Refresh target list cache (~every 500ms while overlay is open)
-        if ui_state.show_target_list {
-            ui_state.target_list_tick += 1;
-            if ui_state.target_list_cache.is_none() || ui_state.target_list_tick.is_multiple_of(30)
-            {
-                ui_state.target_list_cache = Some(extract_target_infos(&sessions, &targets));
+        if dirty {
+            let session_snapshot = {
+                let sessions_read = sessions.read();
+                sessions_read
+                    .get(&current_target)
+                    .map(|state| state.read().snapshot_for_render())
+            };
+
+            if let Some(ref session) = session_snapshot {
+                terminal.draw(|f| {
+                    draw_ui(
+                        f,
+                        session,
+                        ui_state,
+                        &theme,
+                        num_targets,
+                        cache_status.clone(),
+                        ix_enabled,
+                    );
+                })?;
+            } else {
+                terminal.draw(|f| {
+                    draw_empty_state(f, ui_state, &theme, cache_status.clone(), ix_enabled);
+                })?;
             }
-        } else {
-            ui_state.target_list_cache = None;
-            ui_state.target_list_tick = 0;
+            last_draw = Some(fingerprint);
         }
-
-        // Draw (no locks held — all data is pre-extracted snapshots)
-        if let Some(ref session) = session_snapshot {
-            terminal.draw(|f| {
-                draw_ui(
-                    f,
-                    session,
-                    ui_state,
-                    &theme,
-                    num_targets,
-                    cache_status.clone(),
-                    ix_enabled,
-                );
-            })?;
-        } else {
-            // No targets yet (interactive empty mode)
-            terminal.draw(|f| {
-                draw_empty_state(f, ui_state, &theme, cache_status.clone(), ix_enabled);
-            })?;
-        }
-
         // Handle input — non-blocking: the event-reader thread forwards
         // crossterm events over the channel so we never stall the async runtime.
         if let Ok(Event::Key(key)) = event_rx.try_recv() {
@@ -1584,5 +1710,136 @@ mod tests {
         let replay = ui_state.replay_state.as_ref().unwrap();
         assert_eq!(replay.current_index, 0);
         assert!(replay.paused);
+    }
+
+    #[test]
+    fn test_fingerprint_changes_when_status_expires() {
+        let mut ui_state = UiState {
+            status_message: Some((
+                "Working".to_string(),
+                std::time::Instant::now() - Duration::from_secs(4),
+            )),
+            ..UiState::default()
+        };
+        let before = render_fingerprint(&ui_state, 1, Some(0), None);
+        ui_state.clear_old_status();
+        let after = render_fingerprint(&ui_state, 1, Some(0), None);
+        assert!(ui_state.status_message.is_none());
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_fingerprint_changes_on_add_target_poll() {
+        let existing = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
+        let added = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+        let mut targets = vec![existing];
+        let mut ui_state = UiState {
+            target_input: TargetInputState {
+                resolving: true,
+                ..TargetInputState::default()
+            },
+            show_target_input: true,
+            ..UiState::default()
+        };
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        ui_state.target_input.pending = Some(rx);
+        let before = render_fingerprint(&ui_state, targets.len(), Some(0), None);
+        tx.send(Ok(crate::tui::views::AddedTarget {
+            ip: added,
+            name: "dns.google".to_string(),
+            existed: false,
+        }))
+        .unwrap();
+        poll_add_target_result(&mut ui_state, &mut targets);
+        let after = render_fingerprint(&ui_state, targets.len(), Some(0), None);
+        assert_eq!(targets, vec![existing, added]);
+        assert_eq!(ui_state.selected_target, 1);
+        assert!(!ui_state.show_target_input);
+        assert!(ui_state.status_message.is_some());
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_fingerprint_changes_on_update_check_recv() {
+        let mut ui_state = UiState::default();
+        let (tx, rx) = std::sync::mpsc::channel();
+        ui_state.update_rx = Some(rx);
+        let before = render_fingerprint(&ui_state, 1, Some(0), None);
+        tx.send(Some("0.22.0".to_string())).unwrap();
+        poll_update_check(&mut ui_state);
+        let after = render_fingerprint(&ui_state, 1, Some(0), None);
+        assert_eq!(ui_state.update_available.as_deref(), Some("0.22.0"));
+        assert!(ui_state.update_rx.is_none());
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_fingerprint_changes_when_open_target_list_refreshes() {
+        let current = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
+        let other = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
+        let current_session =
+            Session::new(Target::new("a".to_string(), current), Config::default());
+        let other_session = Session::new(Target::new("b".to_string(), other), Config::default());
+        let mut map = HashMap::new();
+        map.insert(current, Arc::new(parking_lot::RwLock::new(current_session)));
+        map.insert(other, Arc::new(parking_lot::RwLock::new(other_session)));
+        let sessions: SessionMap = Arc::new(parking_lot::RwLock::new(map));
+        let targets = vec![current, other];
+
+        let mut ui_state = UiState {
+            show_target_list: true,
+            target_list_tick: 29,
+            target_list_cache: Some(extract_target_infos(&sessions, &targets)),
+            ..UiState::default()
+        };
+        let current_gen = sessions
+            .read()
+            .get(&current)
+            .unwrap()
+            .read()
+            .render_generation;
+        let before = render_fingerprint(&ui_state, targets.len(), Some(current_gen), None);
+
+        {
+            let sessions_read = sessions.read();
+            let mut other_session = sessions_read.get(&other).unwrap().write();
+            other_session.dest_ttl = Some(1);
+            if let Some(hop) = other_session.hop_mut(1) {
+                hop.sent = 10;
+                hop.received = 5;
+            }
+        }
+
+        refresh_target_list_cache(&mut ui_state, &sessions, &targets);
+        let current_gen_after = sessions
+            .read()
+            .get(&current)
+            .unwrap()
+            .read()
+            .render_generation;
+        let after = render_fingerprint(&ui_state, targets.len(), Some(current_gen_after), None);
+
+        assert_eq!(current_gen, current_gen_after);
+        assert_eq!(ui_state.target_list_tick, 30);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_fingerprint_includes_ix_fetched_at() {
+        let stale = crate::lookup::ix::CacheStatus {
+            loaded: true,
+            prefix_count: 3,
+            fetched_at: Some(1),
+            expired: false,
+            refreshing: false,
+        };
+        let fresh = crate::lookup::ix::CacheStatus {
+            fetched_at: Some(2),
+            ..stale.clone()
+        };
+        let ui_state = UiState::default();
+        let a = render_fingerprint(&ui_state, 0, None, Some(&stale));
+        let b = render_fingerprint(&ui_state, 0, None, Some(&fresh));
+        assert_ne!(a, b);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1580,6 +1580,7 @@ fn draw_ui(
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::state::SessionLock;
     use crate::state::Target;
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1587,7 +1588,7 @@ mod tests {
 
     fn make_single_session_map(target: IpAddr, session: Session) -> SessionMap {
         let mut map = HashMap::new();
-        map.insert(target, Arc::new(parking_lot::RwLock::new(session)));
+        map.insert(target, Arc::new(SessionLock::new(session)));
         Arc::new(parking_lot::RwLock::new(map))
     }
 
@@ -1781,8 +1782,8 @@ mod tests {
             Session::new(Target::new("a".to_string(), current), Config::default());
         let other_session = Session::new(Target::new("b".to_string(), other), Config::default());
         let mut map = HashMap::new();
-        map.insert(current, Arc::new(parking_lot::RwLock::new(current_session)));
-        map.insert(other, Arc::new(parking_lot::RwLock::new(other_session)));
+        map.insert(current, Arc::new(SessionLock::new(current_session)));
+        map.insert(other, Arc::new(SessionLock::new(other_session)));
         let sessions: SessionMap = Arc::new(parking_lot::RwLock::new(map));
         let targets = vec![current, other];
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -782,7 +782,13 @@ where
         }
         // Handle input — non-blocking: the event-reader thread forwards
         // crossterm events over the channel so we never stall the async runtime.
-        if let Ok(Event::Key(key)) = event_rx.try_recv() {
+        let event = event_rx.try_recv().ok();
+        // A resize changes the layout without touching any fingerprinted state,
+        // so force the next tick to draw (terminal.draw re-measures the area).
+        if matches!(event, Some(Event::Resize(..))) {
+            last_draw = None;
+        }
+        if let Some(Event::Key(key)) = event {
             if key.kind != KeyEventKind::Press {
                 continue;
             }


### PR DESCRIPTION
Skip `snapshot_for_render()` + `terminal.draw` on ticks where nothing changed (LAN-1222).

**What changes**
- `Session::render_generation` is bumped by the `SessionLock` write guard on release, so every mutation path — hop stats, enrichment, PMTUD, pause/reset — marks the TUI dirty. A writer that bypasses the lock is a compile error, not a stale frame.
- After the pre-draw polls, the loop builds a `RenderFingerprint` (session generation, overlays, theme, status, update banner, replay clock, settings, target input, IX cache status, target-list rows) and skips the snapshot and draw when it matches the last frame.
- Tick stays 16ms; a playing replay stays dirty via `replay_current_ms`. A terminal resize invalidates the last fingerprint so the next tick redraws.

**Measured** — docker, `ttl 1.1.1.1`, 9 hops, 60s, both binaries in the same network window:

| | CPU over 60s | avg of one core |
|---|---|---|
| master | 0.86s | 1.43% |
| this PR | 0.22s | 0.37% |

**Not covered**
- `format_cache_age` in the settings modal reads the wall clock at render time, so its "Xm ago" text only refreshes when something else on screen changes.
