### PR TITLE
chore: clippy 1.98 nits (prerequisite)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1674,7 +1674,7 @@ fn emit_stream_events(sessions: &SessionMap, targets: &[IpAddr]) -> Result<()> {
                 if session.events.is_empty() {
                     continue;
                 }
-                session.events.drain(..).collect()
+                std::mem::take(&mut session.events)
             };
             for event in &events {
                 write_event_line(&mut out, *target_ip, event)?;

--- a/src/probe/correlate.rs
+++ b/src/probe/correlate.rs
@@ -103,9 +103,8 @@ fn parse_icmp_extensions_with_length(
             let mut labels = Vec::new();
 
             // Each label entry is 4 bytes
-            for chunk in label_data.chunks_exact(4) {
-                // chunks_exact(4) guarantees chunk.len() == 4, so this is infallible
-                let bytes: [u8; 4] = [chunk[0], chunk[1], chunk[2], chunk[3]];
+            for chunk in label_data.as_chunks::<4>().0 {
+                let bytes: [u8; 4] = *chunk;
                 let label = MplsLabel::from_bytes(&bytes);
                 labels.push(label);
                 // Stop at bottom of stack


### PR DESCRIPTION
Prerequisite for the LAN-1114 and LAN-1222 drafts.

Current master fails `cargo clippy -D warnings` on rustc 1.98 (`chunks_exact_to_as_chunks` in MPLS parse, `manual_flatten` on stream-json event drain). Both later drafts previously copied these nits so hooks would pass; that misstated scope and would conflict if merged in sequence.

This PR is **only**:
- `src/probe/correlate.rs`: `as_chunks::<4>()`
- `src/main.rs`: `mem::take` instead of `drain(..).collect()`

Merge this first. Then #128 is lockfile-only and #129 is TUI/session-only. A lockfile-only or dirty-skip commit against master will still fail the local clippy hook until this lands.